### PR TITLE
ci(runner): publish multi-arch images

### DIFF
--- a/.github/workflows/publish-runner-images.yml
+++ b/.github/workflows/publish-runner-images.yml
@@ -63,4 +63,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Runner images now publish both `linux/amd64` and `linux/arm64` variants, so Apple Silicon Docker hosts can pull the default GHCR tags without forcing an amd64 platform.

Verification:
- `git diff --check HEAD^..HEAD`
- workflow platform assertion for `linux/amd64,linux/arm64`
- local arm64 Go and C++17 runner image builds
- `RUNNER_IMAGES_PREPARE=build make smoke-real-docker`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT_5-000000)