### PR TITLE
feat(judge): add runtime readiness operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ make smoke-runner-capacity
 SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity
 ```
 
+Judge runtime readiness, recovery operations, and the latest local validation evidence are documented in [docs/judge-runtime-readiness.md](docs/judge-runtime-readiness.md). The current runner capacity report is [docs/runner-capacity-report-2026-07-06.md](docs/runner-capacity-report-2026-07-06.md).
+
 The Docker runner path uses [deploy/docker-compose.docker-runner.yaml](deploy/docker-compose.docker-runner.yaml). Only `soj-judge-agent` receives the Docker socket; runner containers do not receive business service credentials or the Docker socket.
 
 ## Development

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -129,6 +129,8 @@ make smoke-runner-capacity
 SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity
 ```
 
+Judge runtime readiness、恢复操作和最新本地验证证据记录在 [docs/judge-runtime-readiness.md](docs/judge-runtime-readiness.md)。当前 runner 容量报告是 [docs/runner-capacity-report-2026-07-06.md](docs/runner-capacity-report-2026-07-06.md)。
+
 Docker runner 路径使用 [deploy/docker-compose.docker-runner.yaml](deploy/docker-compose.docker-runner.yaml)。只有 `soj-judge-agent` 持有 Docker socket；runner 容器不会拿到业务服务凭据或 Docker socket。
 
 ## 开发

--- a/docs/judge-runtime-readiness.md
+++ b/docs/judge-runtime-readiness.md
@@ -1,0 +1,102 @@
+# Judge Runtime Readiness
+
+This document is the operational checklist for running the SOJ judge runtime in a trial deployment. It covers readiness probes, dead-task recovery, runtime metrics, and the local validation environment used for this stage.
+
+## Readiness Probes
+
+All services keep `GET /healthz` as liveness and `GET /readyz` as dependency readiness.
+
+| Process | Readiness dependencies |
+| --- | --- |
+| `soj-api` | PostgreSQL |
+| `soj-worker` | PostgreSQL, Redis request stream, Redis result stream, object storage bucket |
+| `soj-judge-agent` | Redis request stream, Redis result stream, object storage bucket, sandbox backend probe |
+
+Readiness failures return HTTP 503 with a generic response. Dependency names and failure counts are exposed through metrics rather than HTTP response bodies, so secrets, DSNs, bucket names, and internal addresses are not leaked.
+
+Local checks:
+
+```bash
+curl -fsS http://localhost:8080/readyz
+curl -fsS http://localhost:8081/readyz
+curl -fsS http://localhost:8082/readyz
+```
+
+## Dead Task Recovery
+
+The worker writes exhausted judge tasks to PostgreSQL as `judge_tasks.status = 'dead'` and writes a diagnostic Redis dead-letter entry. PostgreSQL remains the recovery source of truth.
+
+Recover one dead task:
+
+```bash
+docker compose -f deploy/docker-compose.yaml -f deploy/docker-compose.docker-runner.yaml \
+  exec worker /app/soj recover-dead-task \
+  -task-id 123 \
+  -reason "manual recovery after runner fix"
+```
+
+Recovery rules:
+
+- The task must still be `dead`.
+- The linked submission must still be `system_error`.
+- The task is reset to `pending`.
+- The task retry budget is reset with `attempts = 0`.
+- `next_run_at` is set to the recovery time.
+- The submission is reset to `queued` and `judged_at = NULL`.
+- Redis dead-letter entries remain as diagnostic evidence; they are not the replay source.
+
+## Metrics
+
+Runtime readiness and recovery metrics:
+
+- `soj_readiness_checks_total{service,dependency,result}`
+- `soj_readiness_check_duration_seconds{service,dependency,result}`
+- `soj_worker_reconciliation_total{service,action,result}`
+- `soj_worker_judge_task_recovery_total{service,action,result}`
+
+Existing judge runtime metrics to keep on dashboards:
+
+- `soj_worker_judge_task_dispatch_total{result}`
+- `soj_worker_judge_tasks_total{result}`
+- `soj_worker_judge_task_duration_seconds{result}`
+- `soj_judge_agent_slots_used{scope,language}`
+- `soj_judge_agent_slots_capacity{scope,language}`
+- `soj_sandbox_phase_duration_seconds{backend,phase,result}`
+- `soj_sandbox_backend_errors_total{backend,phase,class}`
+- `soj_sandbox_cleanup_failures_total{backend}`
+
+Local Prometheus is available at `http://localhost:9090` when the Compose stack is running.
+
+## Local Validation Environment
+
+The 2026-07-06 validation used:
+
+- macOS Darwin 25.5.0 arm64
+- Apple M5, 10 CPU cores, 24 GiB memory
+- Docker context: `orbstack`
+- Docker client/server: `29.4.0`
+- Docker runtimes: `runc`; `runsc` was not registered
+- Runner images:
+  - `ghcr.io/sparklyi/soj-runner-go:main@sha256:148de7dcab3eada409f7a590a998d2b3123cd955a59029b2dadcdce238902e11`
+  - `ghcr.io/sparklyi/soj-runner-cpp17:main@sha256:60025cca9d106bc45b7c02cdb899b56a2a5561be58497746471f9f0b0f786c31`
+
+Validation commands:
+
+```bash
+go test ./...
+go vet ./...
+docker compose -f deploy/docker-compose.yaml config
+RUNNER_IMAGES_PREPARE=pull make smoke-real-docker
+SOJ_DOCKER_RUNNER_RUNTIME=runsc RUNNER_IMAGES_PREPARE=skip make smoke-runner-capacity
+RUNNER_IMAGES_PREPARE=skip SOJ_CAPACITY_SKIP_BUILD=1 make smoke-runner-capacity
+```
+
+Results are recorded in [runner-capacity-report-2026-07-06.md](runner-capacity-report-2026-07-06.md).
+
+## Troubleshooting
+
+- `/readyz` fails for worker: check PostgreSQL connectivity, Redis stream/group creation, object storage bucket existence, and `soj_readiness_checks_total`.
+- `/readyz` fails for judge-agent: check Redis streams, object storage credentials, sandbox backend probe, runner images, and Docker/runtime registration.
+- Queue grows but no results arrive: check judge-agent readiness, `soj_judge_agent_slots_used`, Redis request/result streams, and sandbox backend errors.
+- Dead tasks accumulate: inspect `judge_tasks.last_error`, Redis `soj:judge:tasks:dead`, and `soj_worker_reconciliation_total`; recover individual tasks only after fixing the underlying dependency.
+- Capacity does not scale with more slots: compare `container_startup_p95_ms`, attempt latency, agent memory peak, queue oldest pending age, and sandbox error deltas.

--- a/docs/runner-capacity-report-2026-07-06.md
+++ b/docs/runner-capacity-report-2026-07-06.md
@@ -1,0 +1,88 @@
+# Runner Capacity Report - 2026-07-06
+
+## Summary
+
+The local runsc capacity test could not run because Docker did not have the `runsc` runtime registered. A default Docker runtime capacity run completed as a non-production comparison.
+
+This report is not a production capacity claim. Production capacity still requires a judge node with Docker plus gVisor/runsc installed and validated.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Branch | `feat/judge-runtime-readiness` |
+| Base commit | `afa2105` |
+| OS | Darwin 25.5.0 arm64 |
+| CPU | Apple M5, 10 cores |
+| Memory | 24 GiB |
+| Docker context | `orbstack` |
+| Docker version | client/server `29.4.0` |
+| Docker runtimes | `runc`; `runsc` unavailable |
+| Runner workdir | `/tmp/soj-runner-work` |
+| Go runner image | `ghcr.io/sparklyi/soj-runner-go:main@sha256:148de7dcab3eada409f7a590a998d2b3123cd955a59029b2dadcdce238902e11` |
+| C++17 runner image | `ghcr.io/sparklyi/soj-runner-cpp17:main@sha256:60025cca9d106bc45b7c02cdb899b56a2a5561be58497746471f9f0b0f786c31` |
+
+Both runner images expose `linux/amd64` and `linux/arm64` manifests.
+
+## Commands
+
+General checks:
+
+```bash
+go test ./...
+go vet ./...
+docker compose -f deploy/docker-compose.yaml config
+RUNNER_IMAGES_PREPARE=pull make smoke-real-docker
+```
+
+runsc capacity attempt:
+
+```bash
+SOJ_DOCKER_RUNNER_RUNTIME=runsc RUNNER_IMAGES_PREPARE=skip make smoke-runner-capacity
+```
+
+Result:
+
+```text
+docker runtime runsc is not registered
+make: *** [smoke-runner-capacity] Error 1
+```
+
+Default Docker comparison:
+
+```bash
+RUNNER_IMAGES_PREPARE=skip SOJ_CAPACITY_SKIP_BUILD=1 make smoke-runner-capacity
+```
+
+## Verification Results
+
+| Check | Result |
+| --- | --- |
+| `go test ./...` | Passed |
+| `go vet ./...` | Passed |
+| `docker compose -f deploy/docker-compose.yaml config` | Passed |
+| `RUNNER_IMAGES_PREPARE=pull make smoke-real-docker` | Passed: `smoke ok: problem=1 submission=1 contest=1 contest_submission=3 judge_results=3 async_rows=2 case_results=2` |
+| `SOJ_DOCKER_RUNNER_RUNTIME=runsc ... make smoke-runner-capacity` | Blocked: Docker runtime `runsc` is not registered |
+| Default Docker `make smoke-runner-capacity` | Passed |
+
+## Default Docker Capacity Data
+
+| Slots | Submissions | Accepted | Submissions/min | P95 latency ms | P99 latency ms | P95 attempt ms | P99 attempt ms | Startup P95 ms | Startup P99 ms | Agent memory peak MiB | Queue oldest pending max s | Sandbox errors | Cleanup failures |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 4 | 4 | 30.14 | 7677.46 | 7899.57 | 7608.32 | 7830.12 | 378 | 378 | 30.38 | 7.08 | 0 | 0 |
+| 2 | 8 | 8 | 43.97 | 10885.40 | 10892.83 | 10471.48 | 10477.51 | 245 | 245 | 25.61 | 9.82 | 0 | 0 |
+| 4 | 16 | 16 | 66.02 | 14472.62 | 14504.51 | 14311.45 | 14341.04 | 206 | 206 | 44.32 | 12.88 | 0 | 0 |
+| 8 | 32 | 32 | 62.87 | 30420.76 | 30485.04 | 28250.97 | 28283.77 | 242 | 242 | 80.70 | 28.16 | 0 | 0 |
+| 16 | 64 | 64 | 70.45 | 54114.53 | 54269.97 | 49977.44 | 50077.20 | 216 | 216 | 159.70 | 52.94 | 0 | 0 |
+
+## Findings
+
+- The local Docker comparison is stable functionally: all submitted jobs reached `accepted`, and sandbox backend/cleanup error deltas stayed at zero.
+- Throughput plateaus after 4 slots in this environment, while queue age and p95 latency grow sharply. This points to local Docker/OrbStack runner startup or host scheduling limits, not an application correctness failure.
+- No runsc production conclusion can be drawn from this machine because `runsc` is not registered.
+
+## Next Actions
+
+- Run the same `SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity` command on a Linux judge node with gVisor installed.
+- Capture the same table for runsc and compare against the default Docker baseline above.
+- If runsc also plateaus below target, profile container startup cost and consider a warmed runner pool or per-attempt case runner reuse.

--- a/docs/superpowers/plans/2026-07-06-soj-judge-runtime-production-readiness.md
+++ b/docs/superpowers/plans/2026-07-06-soj-judge-runtime-production-readiness.md
@@ -1,0 +1,102 @@
+# SOJ Judge Runtime Production Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the judge runtime ready for serious trial deployment with dependency readiness checks, dead-task recovery, runtime metrics, and documented local/runsc validation evidence.
+
+**Architecture:** Keep the async judge architecture unchanged. Add small readiness probe adapters at the process boundary, a worker-owned recovery command that treats PostgreSQL as the source of truth, and metrics/reporting around those operational paths.
+
+**Tech Stack:** Go 1.24, Gin health routes, pgx/sqlc, go-redis, MinIO client, Prometheus client, Docker Compose, gVisor/runsc tooling.
+
+---
+
+## File Structure
+
+- Modify `internal/observability/health.go` and tests for named readiness check results and metrics recording.
+- Modify `internal/observability/metrics.go` and tests for readiness, recovery, and reconciler counters/histograms.
+- Modify `internal/queue/queue.go`, `internal/queue/redis_stream.go`, and tests to expose lightweight Redis stream readiness.
+- Modify `internal/storage/storage.go`, `internal/storage/s3.go`, and tests to expose object storage readiness.
+- Modify `internal/app/worker.go` to assemble worker readiness and route `recover-dead-task`.
+- Modify `internal/app/judge_agent.go` to assemble judge-agent readiness with Redis, storage, and sandbox probe checks.
+- Modify `internal/submission/repository.go`, `internal/postgres/queries/submissions.sql`, and generated sqlc output for dead task recovery.
+- Modify `internal/submission/reconciler.go` and tests to record reconciliation metrics.
+- Add `docs/judge-runtime-readiness.md` and `docs/runner-capacity-report-2026-07-06.md`.
+- Update `README.md`, `README.zh-CN.md`, and `docs/v2-deploy.md` links/status.
+
+## Chunk 1: Readiness And Metrics Foundations
+
+**Files:**
+- Modify: `internal/observability/health.go`
+- Modify: `internal/observability/health_test.go`
+- Modify: `internal/observability/metrics.go`
+- Modify: `internal/observability/metrics_test.go`
+- Modify: `internal/queue/queue.go`
+- Modify: `internal/queue/redis_stream.go`
+- Modify: `internal/queue/redis_stream_test.go`
+- Modify: `internal/storage/storage.go`
+- Modify: `internal/storage/s3.go`
+
+- [ ] Add failing tests for readiness checks recording dependency success/failure without leaking sensitive error details.
+- [ ] Add failing tests for queue readiness checking stream/group visibility.
+- [ ] Add failing tests for metrics exposure: readiness checks, recovery actions, reconciler actions.
+- [ ] Implement minimal readiness result recording and metrics methods.
+- [ ] Implement queue/storage readiness methods.
+- [ ] Run `go test ./internal/observability ./internal/queue ./internal/storage`.
+
+## Chunk 2: Worker And Judge-Agent Readiness Wiring
+
+**Files:**
+- Modify: `internal/app/worker.go`
+- Modify: `internal/app/judge_agent.go`
+- Add or modify app tests if existing seams are sufficient.
+- Modify: `docs/v2-deploy.md`
+
+- [ ] Add failing tests or small seam tests proving worker readiness includes PostgreSQL, request Redis stream, result Redis stream, and object storage.
+- [ ] Add failing tests or seam tests proving judge-agent readiness includes Redis streams, object storage, and sandbox probe.
+- [ ] Wire worker `ReadyCheck` into `httpapi.NewRouter`.
+- [ ] Replace judge-agent single Redis ping readiness with composed readiness.
+- [ ] Document current readiness checks in deploy docs.
+- [ ] Run `go test ./internal/app ./internal/observability ./internal/queue ./internal/storage`.
+
+## Chunk 3: Dead Task Recovery
+
+**Files:**
+- Modify: `internal/postgres/queries/submissions.sql`
+- Regenerate: `internal/postgres/db/submissions.sql.go`, `internal/postgres/db/querier.go`
+- Modify: `internal/submission/repository.go`
+- Modify: `internal/submission/reconciler.go`
+- Modify or add: `internal/submission/*_test.go`
+- Modify: `internal/app/worker.go`
+
+- [ ] Add failing repository/memory tests for recovering a `dead` judge task back to `pending`.
+- [ ] Add SQL query `RecoverDeadJudgeTask`.
+- [ ] Regenerate sqlc output with the project command or available `sqlc`.
+- [ ] Implement repository method and memory test support.
+- [ ] Add `soj-worker recover-dead-task -task-id <id> [-reason <text>]`.
+- [ ] Add metrics for recovery success, not-found/not-dead, and errors.
+- [ ] Run `go test ./internal/submission ./internal/app`.
+
+## Chunk 4: Validation Docs And Capacity Report
+
+**Files:**
+- Add: `docs/judge-runtime-readiness.md`
+- Add: `docs/runner-capacity-report-2026-07-06.md`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `docs/v2-deploy.md`
+
+- [ ] Run local verification commands and capture exact results.
+- [ ] Attempt `SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity`.
+- [ ] If runsc is unavailable locally, record the exact blocker and run Docker capacity smoke as non-production comparison.
+- [ ] Write readiness and recovery operations doc.
+- [ ] Write capacity report with environment, commands, observed output, bottlenecks, and next action.
+- [ ] Add README/deploy doc links.
+
+## Final Verification
+
+- [ ] `go test ./...`
+- [ ] `go vet ./...`
+- [ ] `docker compose -f deploy/docker-compose.yaml config`
+- [ ] `make smoke-real-docker`
+- [ ] `SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity` or documented blocker plus Docker comparison
+- [ ] Go feature-change review of modified Go code before commit/PR

--- a/docs/superpowers/specs/2026-07-06-soj-judge-runtime-production-readiness-design.md
+++ b/docs/superpowers/specs/2026-07-06-soj-judge-runtime-production-readiness-design.md
@@ -1,0 +1,95 @@
+# SOJ Judge Runtime Production Readiness Design
+
+日期：2026-07-06
+
+## Decision
+
+本阶段把已经能本地真实评测的 Docker/gVisor runner 主线，推进到可以认真部署试运行的状态。范围锁定为四类能力：readiness、dead-letter/恢复、关键指标和一次 runsc 容量报告。
+
+这个阶段不继续扩展评测语言、不做新的调度服务，也不把 scoreboard snapshot、OpenTelemetry tracing 或前端后台纳入同一批改动。
+
+## Goals
+
+- Worker 和 judge-agent 的 `/readyz` 能反映关键依赖，而不是只证明进程还活着。
+- 已 dead-letter 或卡住的 judge task 有可记录、可重复执行的恢复路径。
+- 评测运行时暴露足够的 Prometheus 指标，用于判断队列、恢复、sandbox 和 agent 容量是否健康。
+- 跑一次 runsc 容量验证，记录环境、命令、结果、瓶颈和下一步建议。
+- 输出可挂到 README 和部署文档的验证文档，包含本地验证环境、测试命令、测试结果和排障入口。
+
+## Non-Goals
+
+- 不实现新的比赛 scoreboard 自动快照。
+- 不接入 OpenTelemetry tracing。
+- 不实现多机 scheduler 或 runner warm pool。
+- 不改变 judge request/result 协议版本。
+- 不把普通 Docker runtime 视为生产隔离方案。
+
+## Readiness
+
+API readiness 已检查 PostgreSQL，本阶段补齐 worker 和 judge-agent：
+
+- `soj-worker` readiness 检查 PostgreSQL、Redis request stream、Redis result stream 和对象存储可用性。
+- `soj-judge-agent` readiness 检查 Redis request stream、Redis result stream、对象存储和 sandbox backend capability probe。
+- readiness 失败继续返回 HTTP 503，错误细节只进入日志或内部指标，避免把凭据、DSN 或内部地址暴露给普通 HTTP 响应。
+- 检查函数保持小而可单测，运行时入口只负责组装依赖。
+
+## Dead-Letter And Recovery
+
+现有 worker 已能在任务耗尽重试后写 PostgreSQL `dead` 状态和 Redis dead-letter stream。缺口是运维恢复入口和恢复结果观测。
+
+本阶段新增一个最小 CLI/命令模式，用于把指定 dead task 恢复为 pending：
+
+- 输入 task id 和可选 reason。
+- 只允许恢复 PostgreSQL 中仍处于 `dead` 的 judge task。
+- 恢复时把 task 状态改回 `pending`、`next_run_at=now()`，递增或保留 attempts 的行为必须明确记录。
+- 对应 submission 从 `system_error` 恢复为 `queued`。
+- 命令输出恢复数量和未恢复原因，便于贴到事故记录。
+
+Redis dead-letter stream 保留为诊断证据，不在第一版做自动回放所有 dead-letter 消息，避免绕过 PostgreSQL 事实源。
+
+## Metrics
+
+新增或强化以下指标：
+
+- readiness dependency check total/duration by service、dependency、result。
+- worker recovery total by action/result。
+- reconciler reset/stale-run total by action/result。
+- judge-agent readiness sandbox probe result。
+
+保留现有指标：
+
+- `soj_worker_judge_task_dispatch_total`
+- `soj_worker_judge_tasks_total`
+- `soj_worker_judge_task_duration_seconds`
+- `soj_judge_agent_slots_used`
+- `soj_judge_agent_slots_capacity`
+- `soj_sandbox_phase_duration_seconds`
+- `soj_sandbox_backend_errors_total`
+- `soj_sandbox_cleanup_failures_total`
+
+## Capacity Report
+
+容量报告不是泛泛写一段说明，而是本阶段完成时提交一份可复现报告：
+
+- 记录 Docker、runsc、runner image、host CPU/memory、SOJ commit。
+- 记录实际命令，包括 `SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity` 或降级原因。
+- 记录 `1/2/4/8/16` slot profile 的 submissions/minute、P95/P99 latency、container startup、agent memory、queue oldest pending age、backend error delta 和 cleanup failure delta。
+- 如果本机无法跑 runsc，报告必须明确写出阻塞原因，并保留普通 Docker capacity 作为对照，不把它标记为生产容量结论。
+
+## Documentation Output
+
+完成阶段时更新：
+
+- `docs/judge-runtime-readiness.md`：readiness 检查、恢复操作、关键指标、排障步骤、本地验证环境。
+- `docs/runner-capacity-report-2026-07-06.md`：本次容量验证报告。
+- `README.md` 和 `README.zh-CN.md`：增加指向 readiness 文档和容量报告的链接。
+- `docs/v2-deploy.md`：把 worker/judge-agent readiness 从“待扩展”更新为当前生产试运行检查项。
+
+## Acceptance
+
+- 单元测试覆盖 readiness dependency failures、dead task recovery 和新增指标注册。
+- `go test ./...` 通过。
+- `go vet ./...` 通过。
+- `docker compose -f deploy/docker-compose.yaml config` 通过。
+- `make smoke-real-docker` 或等价真实 Docker runner smoke 通过。
+- 尝试 runsc capacity smoke，并把结果或阻塞原因写入报告。

--- a/docs/v2-deploy.md
+++ b/docs/v2-deploy.md
@@ -63,7 +63,13 @@ Do not commit production DSNs, JWT secrets, or object storage credentials.
 - Judge agent liveness: `GET /healthz`
 - Judge agent readiness: `GET /readyz`
 
-Current API readiness checks PostgreSQL. Worker readiness is process-level only; Redis/object storage/judge readiness is exercised by `deploy/smoke.sh` and worker logs. Add broader dependency probes before using these health checks as production traffic gates.
+Current readiness checks:
+
+- API readiness checks PostgreSQL.
+- Worker readiness checks PostgreSQL, Redis request stream, Redis result stream, and object storage.
+- Judge-agent readiness checks Redis request stream, Redis result stream, object storage, and the configured sandbox backend probe.
+
+See `docs/judge-runtime-readiness.md` for the operational checklist, recovery command, metrics, and local validation environment.
 
 ## Metrics
 
@@ -112,6 +118,8 @@ SOJ_DOCKER_RUNNER_RUNTIME=runsc make smoke-runner-capacity
 ```
 
 The capacity smoke recreates the local Docker runner stack and runs `1/2/4/8/16` judge-agent slot profiles by default. It prints submissions per minute, P95/P99 submission latency, P95/P99 judge attempt duration, no-op container startup overhead, maximum attempt memory, judge-agent memory curve, queue oldest pending age, backend error deltas, and cleanup failure deltas. Override the profile with `SOJ_CAPACITY_SLOTS`, `SOJ_CAPACITY_SUBMISSIONS_PER_SLOT`, `SOJ_CAPACITY_SUBMISSIONS_MAX`, `SOJ_CAPACITY_TIME_LIMIT_MS`, and `SOJ_CAPACITY_SKIP_BUILD=1` for heavier or repeated manual tests.
+
+The latest local capacity evidence is recorded in `docs/runner-capacity-report-2026-07-06.md`.
 
 Backend safety matrix:
 

--- a/internal/app/judge_agent.go
+++ b/internal/app/judge_agent.go
@@ -61,8 +61,12 @@ func RunJudgeAgent(ctx context.Context, args []string, stdout, stderr io.Writer)
 		Stream:   envOr("SOJ_JUDGE_RESULT_STREAM", cfg.Redis.Stream+":results"),
 		Group:    envOr("SOJ_JUDGE_RESULT_GROUP", "judge-result-consumers"),
 		Consumer: judgeAgentConsumerName(),
+		StartID:  "0",
 	})
 	if err := requestQueue.Ensure(ctx); err != nil {
+		return err
+	}
+	if err := resultQueue.Ensure(ctx); err != nil {
 		return err
 	}
 
@@ -80,14 +84,13 @@ func RunJudgeAgent(ctx context.Context, args []string, stdout, stderr io.Writer)
 	}
 	slotLimiter := newJudgeAgentSlotLimiter(parallelism, languageSlots)
 
-	agent, err := newJudgeAgentProcessor(ctx, sandboxBackend, cfg, objectStore, metrics, queueResultPublisher{queue: resultQueue})
+	agent, sandboxReady, err := newJudgeAgentProcessor(ctx, sandboxBackend, cfg, objectStore, metrics, queueResultPublisher{queue: resultQueue})
 	if err != nil {
 		return err
 	}
 
-	router := httpapi.NewRouter(httpapi.RouterOptions{Metrics: metrics, ReadyCheck: func(ctx context.Context) error {
-		return redisClient.Ping(ctx).Err()
-	}})
+	readiness := newJudgeAgentReadiness(requestQueue, resultQueue, objectStore, sandboxReady, metrics)
+	router := httpapi.NewRouter(httpapi.RouterOptions{Metrics: metrics, ReadyCheck: readiness.Check})
 	server := &http.Server{
 		Addr:         *healthAddr,
 		Handler:      router,
@@ -216,31 +219,38 @@ func judgeAgentMessageLanguageKey(message queue.Message) string {
 	return ""
 }
 
-func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Config, objectStore storage.ObjectStorage, observer sandbox.SandboxObserver, publisher submission.ResultPublisher) (judgeRequestProcessor, error) {
+func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Config, objectStore storage.ObjectStorage, observer sandbox.SandboxObserver, publisher submission.ResultPublisher) (judgeRequestProcessor, observability.CheckFunc, error) {
 	sourceStore := submission.NewObjectSourceStore(objectStore)
 	if backend == sandbox.BackendFake {
 		return submission.NewFakeAsyncAgent(submission.FakeAsyncAgentOptions{
 			Judge:           newJudgeEngine(cfg.Judge),
 			SourceStore:     sourceStore,
 			ResultPublisher: publisher,
-		}), nil
+		}), nil, nil
 	}
-	sandboxBackend, err := newJudgeAgentSandbox(backend, observer)
+	runtimeSandbox, err := newJudgeAgentSandbox(backend, observer)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	capabilities, err := sandboxBackend.Probe(ctx)
+	capabilities, err := runtimeSandbox.Probe(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := sandbox.ValidateProductionCapabilities(cfg.Env, capabilities); err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+	sandboxReady := func(ctx context.Context) error {
+		capabilities, err := runtimeSandbox.Probe(ctx)
+		if err != nil {
+			return err
+		}
+		return sandbox.ValidateProductionCapabilities(cfg.Env, capabilities)
 	}
 	return submission.NewCoreAsyncAgent(submission.CoreAsyncAgentOptions{
-		Core:            judgecore.New(judgecore.Options{Sandbox: sandboxBackend}),
+		Core:            judgecore.New(judgecore.Options{Sandbox: runtimeSandbox}),
 		SourceStore:     sourceStore,
 		ResultPublisher: publisher,
-	}), nil
+	}), sandboxReady, nil
 }
 
 func newJudgeAgentSandbox(backend string, observer sandbox.SandboxObserver) (sandbox.Sandbox, error) {

--- a/internal/app/readiness.go
+++ b/internal/app/readiness.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"context"
+
+	"SOJ/internal/observability"
+	"SOJ/internal/queue"
+	"SOJ/internal/storage"
+)
+
+func newWorkerReadiness(dbCheck observability.CheckFunc, requestQueue, resultQueue queue.TaskQueue, objectStore storage.ObjectStorage, metrics observability.ReadinessMetrics) observability.Readiness {
+	return observability.NewReadinessWithMetrics(map[string]observability.CheckFunc{
+		"postgres":             dbCheck,
+		"redis.request_stream": func(ctx context.Context) error { return queue.CheckReady(ctx, requestQueue) },
+		"redis.result_stream":  func(ctx context.Context) error { return queue.CheckReady(ctx, resultQueue) },
+		"object_storage":       func(ctx context.Context) error { return storage.CheckReady(ctx, objectStore) },
+	}, metrics)
+}
+
+func newJudgeAgentReadiness(requestQueue, resultQueue queue.TaskQueue, objectStore storage.ObjectStorage, sandboxCheck observability.CheckFunc, metrics observability.ReadinessMetrics) observability.Readiness {
+	if sandboxCheck == nil {
+		sandboxCheck = func(context.Context) error { return nil }
+	}
+	return observability.NewReadinessWithMetrics(map[string]observability.CheckFunc{
+		"redis.request_stream": func(ctx context.Context) error { return queue.CheckReady(ctx, requestQueue) },
+		"redis.result_stream":  func(ctx context.Context) error { return queue.CheckReady(ctx, resultQueue) },
+		"object_storage":       func(ctx context.Context) error { return storage.CheckReady(ctx, objectStore) },
+		"sandbox":              sandboxCheck,
+	}, metrics)
+}

--- a/internal/app/readiness_test.go
+++ b/internal/app/readiness_test.go
@@ -1,0 +1,112 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"SOJ/internal/queue"
+	"SOJ/internal/storage"
+)
+
+func TestWorkerReadinessChecksRuntimeDependencies(t *testing.T) {
+	requestQueue := &readyQueue{}
+	resultQueue := &readyQueue{}
+	store := &readyObjectStore{}
+	readiness := newWorkerReadiness(
+		func(context.Context) error { return nil },
+		requestQueue,
+		resultQueue,
+		store,
+		nil,
+	)
+
+	if err := readiness.Check(context.Background()); err != nil {
+		t.Fatalf("Check() error = %v", err)
+	}
+	if !requestQueue.called || !resultQueue.called || !store.called {
+		t.Fatalf("readiness did not check all dependencies: request=%v result=%v storage=%v", requestQueue.called, resultQueue.called, store.called)
+	}
+}
+
+func TestJudgeAgentReadinessReportsSandboxProbeFailure(t *testing.T) {
+	wantErr := errors.New("runsc unavailable")
+	readiness := newJudgeAgentReadiness(
+		&readyQueue{},
+		&readyQueue{},
+		&readyObjectStore{},
+		func(context.Context) error { return wantErr },
+		nil,
+	)
+
+	err := readiness.Check(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Check() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWorkerRecoverDeadTaskRequiresTaskID(t *testing.T) {
+	err := RunWorker(context.Background(), []string{"recover-dead-task"}, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "task-id is required") {
+		t.Fatalf("RunWorker error = %v, want task-id requirement", err)
+	}
+}
+
+type readyQueue struct {
+	called bool
+	err    error
+}
+
+func (q *readyQueue) Ensure(context.Context) error { return nil }
+
+func (q *readyQueue) Publish(context.Context, int64, []byte) (string, error) {
+	return "", nil
+}
+
+func (q *readyQueue) Consume(context.Context, int, time.Duration) ([]queue.Message, error) {
+	return nil, nil
+}
+
+func (q *readyQueue) ClaimStale(context.Context, time.Duration, int) ([]queue.Message, error) {
+	return nil, nil
+}
+
+func (q *readyQueue) Ack(context.Context, string) error { return nil }
+
+func (q *readyQueue) DeadLetter(context.Context, queue.Message, string) error {
+	return nil
+}
+
+func (q *readyQueue) Close() error { return nil }
+
+func (q *readyQueue) Ready(context.Context) error {
+	q.called = true
+	return q.err
+}
+
+type readyObjectStore struct {
+	called bool
+	err    error
+}
+
+func (s *readyObjectStore) Put(context.Context, storage.Object) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, nil
+}
+
+func (s *readyObjectStore) Get(context.Context, string) (io.ReadCloser, storage.ObjectInfo, error) {
+	return io.NopCloser(strings.NewReader("")), storage.ObjectInfo{}, nil
+}
+
+func (s *readyObjectStore) Delete(context.Context, string) error { return nil }
+
+func (s *readyObjectStore) Stat(context.Context, string) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, nil
+}
+
+func (s *readyObjectStore) Ready(context.Context) error {
+	s.called = true
+	return s.err
+}

--- a/internal/app/worker.go
+++ b/internal/app/worker.go
@@ -2,7 +2,9 @@ package app
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -22,6 +24,10 @@ import (
 )
 
 func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	if len(args) > 0 && args[0] == "recover-dead-task" {
+		return runWorkerRecoverDeadTask(ctx, args[1:], stdout)
+	}
+
 	fs := flag.NewFlagSet("soj-worker", flag.ContinueOnError)
 	fs.SetOutput(stdout)
 	healthAddr := fs.String("health-addr", "", "worker health HTTP listen address")
@@ -87,9 +93,10 @@ func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) err
 		Metrics:          metrics,
 	})
 	resultConsumer := submission.NewResultConsumer(submission.ResultConsumerOptions{Repository: submissionRepo})
-	reconciler := submission.NewReconciler(submissionRepo, worker, nil)
+	reconciler := submission.NewReconciler(submissionRepo, worker, nil, metrics)
 
-	router := httpapi.NewRouter(httpapi.RouterOptions{Metrics: metrics})
+	readiness := newWorkerReadiness(pool.Ping, taskQueue, resultQueue, objectStore, metrics)
+	router := httpapi.NewRouter(httpapi.RouterOptions{Metrics: metrics, ReadyCheck: readiness.Check})
 	logger.InfoContext(ctx, "starting soj worker", "health_addr", cfg.Worker.HealthAddr, "request_stream", cfg.Redis.Stream, "request_group", cfg.Redis.Group, "result_stream", envOr("SOJ_JUDGE_RESULT_STREAM", cfg.Redis.Stream+":results"), "result_group", envOr("SOJ_JUDGE_RESULT_GROUP", "judge-result-consumers"))
 
 	server := &http.Server{
@@ -225,4 +232,37 @@ func workerConsumerName() string {
 		return hostname
 	}
 	return "worker"
+}
+
+func runWorkerRecoverDeadTask(ctx context.Context, args []string, stdout io.Writer) error {
+	fs := flag.NewFlagSet("soj-worker recover-dead-task", flag.ContinueOnError)
+	fs.SetOutput(stdout)
+	taskID := fs.Int64("task-id", 0, "dead judge task id to recover")
+	reason := fs.String("reason", "manual dead task recovery", "operator-visible recovery reason")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *taskID <= 0 {
+		return errors.New("task-id is required")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	pool, err := postgres.OpenPool(ctx, postgres.PoolConfig{DSN: cfg.Database.DSN})
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	repo := submission.NewSQLRepository(db.New(pool))
+	task, err := repo.RecoverDeadJudgeTask(ctx, *taskID, time.Now().UTC(), *reason)
+	if err != nil {
+		return err
+	}
+	if stdout != nil {
+		_, _ = fmt.Fprintf(stdout, "recovered judge task %d for submission %d as %s\n", task.ID, task.SubmissionID, task.Status)
+	}
+	return nil
 }

--- a/internal/observability/health.go
+++ b/internal/observability/health.go
@@ -2,30 +2,60 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
+	"time"
 )
 
 type CheckFunc func(context.Context) error
 
+type ReadinessMetrics interface {
+	RecordReadinessCheck(dependency, result string, duration time.Duration)
+}
+
 type Readiness struct {
-	checks map[string]CheckFunc
+	checks  map[string]CheckFunc
+	metrics ReadinessMetrics
 }
 
 func NewReadiness(checks map[string]CheckFunc) Readiness {
+	return NewReadinessWithMetrics(checks, nil)
+}
+
+func NewReadinessWithMetrics(checks map[string]CheckFunc, metrics ReadinessMetrics) Readiness {
 	copied := make(map[string]CheckFunc, len(checks))
 	for name, check := range checks {
 		if check != nil {
 			copied[name] = check
 		}
 	}
-	return Readiness{checks: copied}
+	return Readiness{checks: copied, metrics: metrics}
 }
 
 func (r Readiness) Check(ctx context.Context) error {
-	for name, check := range r.checks {
-		if err := check(ctx); err != nil {
-			return fmt.Errorf("%s: %w", name, err)
-		}
+	names := make([]string, 0, len(r.checks))
+	for name := range r.checks {
+		names = append(names, name)
 	}
-	return nil
+	sort.Strings(names)
+
+	var failures []error
+	for _, name := range names {
+		check := r.checks[name]
+		started := time.Now()
+		if err := check(ctx); err != nil {
+			r.record(name, "error", time.Since(started))
+			failures = append(failures, fmt.Errorf("%s: %w", name, err))
+			continue
+		}
+		r.record(name, "success", time.Since(started))
+	}
+	return errors.Join(failures...)
+}
+
+func (r Readiness) record(dependency, result string, duration time.Duration) {
+	if r.metrics != nil {
+		r.metrics.RecordReadinessCheck(dependency, result, duration)
+	}
 }

--- a/internal/observability/health_test.go
+++ b/internal/observability/health_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestReadinessCheckReportsDependencyFailure(t *testing.T) {
@@ -29,4 +30,47 @@ func TestReadinessCheckPassesWithNoFailures(t *testing.T) {
 	if err := checker.Check(context.Background()); err != nil {
 		t.Fatalf("Check() error = %v", err)
 	}
+}
+
+func TestReadinessRecordsDependencyResults(t *testing.T) {
+	wantErr := errors.New("redis unavailable")
+	recorder := &recordingReadinessMetrics{}
+	checker := NewReadinessWithMetrics(map[string]CheckFunc{
+		"postgres": func(context.Context) error { return nil },
+		"redis":    func(context.Context) error { return wantErr },
+	}, recorder)
+
+	err := checker.Check(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Check() error = %v, want wrapped %v", err, wantErr)
+	}
+	if !recorder.saw("postgres", "success") {
+		t.Fatalf("missing postgres success metric: %+v", recorder.records)
+	}
+	if !recorder.saw("redis", "error") {
+		t.Fatalf("missing redis error metric: %+v", recorder.records)
+	}
+}
+
+type readinessMetricRecord struct {
+	dependency string
+	result     string
+	duration   time.Duration
+}
+
+type recordingReadinessMetrics struct {
+	records []readinessMetricRecord
+}
+
+func (m *recordingReadinessMetrics) RecordReadinessCheck(dependency, result string, duration time.Duration) {
+	m.records = append(m.records, readinessMetricRecord{dependency: dependency, result: result, duration: duration})
+}
+
+func (m *recordingReadinessMetrics) saw(dependency, result string) bool {
+	for _, record := range m.records {
+		if record.dependency == dependency && record.result == result {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -23,6 +23,10 @@ type Metrics struct {
 	sandboxPhaseDuration *prometheus.HistogramVec
 	sandboxBackendErrors *prometheus.CounterVec
 	sandboxCleanupFails  *prometheus.CounterVec
+	readinessChecks      *prometheus.CounterVec
+	readinessDuration    *prometheus.HistogramVec
+	taskRecovery         *prometheus.CounterVec
+	reconcilerActions    *prometheus.CounterVec
 }
 
 func NewMetrics(service string) *Metrics {
@@ -104,6 +108,33 @@ func NewMetrics(service string) *Metrics {
 			Help:        "Sandbox workspace or container cleanup failures.",
 			ConstLabels: labels,
 		}, []string{"backend"}),
+		readinessChecks: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   "soj",
+			Name:        "readiness_checks_total",
+			Help:        "Total number of readiness dependency checks.",
+			ConstLabels: labels,
+		}, []string{"dependency", "result"}),
+		readinessDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   "soj",
+			Name:        "readiness_check_duration_seconds",
+			Help:        "Readiness dependency check duration in seconds.",
+			ConstLabels: labels,
+			Buckets:     []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+		}, []string{"dependency", "result"}),
+		taskRecovery: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   "soj",
+			Subsystem:   "worker",
+			Name:        "judge_task_recovery_total",
+			Help:        "Judge task recovery operations by action and result.",
+			ConstLabels: labels,
+		}, []string{"action", "result"}),
+		reconcilerActions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   "soj",
+			Subsystem:   "worker",
+			Name:        "reconciliation_total",
+			Help:        "Worker reconciliation actions by action and result.",
+			ConstLabels: labels,
+		}, []string{"action", "result"}),
 	}
 
 	registry.MustRegister(
@@ -119,6 +150,10 @@ func NewMetrics(service string) *Metrics {
 		metrics.sandboxPhaseDuration,
 		metrics.sandboxBackendErrors,
 		metrics.sandboxCleanupFails,
+		metrics.readinessChecks,
+		metrics.readinessDuration,
+		metrics.taskRecovery,
+		metrics.reconcilerActions,
 	)
 	return metrics
 }
@@ -157,4 +192,20 @@ func (m *Metrics) RecordSandboxBackendError(backend, phase, class string) {
 
 func (m *Metrics) RecordSandboxCleanupFailure(backend string) {
 	m.sandboxCleanupFails.WithLabelValues(backend).Inc()
+}
+
+func (m *Metrics) RecordReadinessCheck(dependency, result string, duration time.Duration) {
+	m.readinessChecks.WithLabelValues(dependency, result).Inc()
+	m.readinessDuration.WithLabelValues(dependency, result).Observe(duration.Seconds())
+}
+
+func (m *Metrics) RecordJudgeTaskRecovery(action, result string) {
+	m.taskRecovery.WithLabelValues(action, result).Inc()
+}
+
+func (m *Metrics) RecordReconcilerAction(action, result string, count int) {
+	if count <= 0 {
+		count = 1
+	}
+	m.reconcilerActions.WithLabelValues(action, result).Add(float64(count))
 }

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -14,6 +14,9 @@ func TestMetricsExposeJudgeAgentAndSandboxSignals(t *testing.T) {
 	metrics.ObserveSandboxPhase("docker", "run", "accepted", 120*time.Millisecond)
 	metrics.RecordSandboxBackendError("docker", "probe", "runtime_unavailable")
 	metrics.RecordSandboxCleanupFailure("docker")
+	metrics.RecordReadinessCheck("redis.request_stream", "success", 10*time.Millisecond)
+	metrics.RecordJudgeTaskRecovery("recover_dead_task", "success")
+	metrics.RecordReconcilerAction("reset_stale_tasks", "success", 2)
 
 	rec := httptest.NewRecorder()
 	metrics.Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
@@ -24,6 +27,10 @@ func TestMetricsExposeJudgeAgentAndSandboxSignals(t *testing.T) {
 		"soj_sandbox_phase_duration_seconds",
 		"soj_sandbox_backend_errors_total",
 		"soj_sandbox_cleanup_failures_total",
+		"soj_readiness_checks_total",
+		"soj_readiness_check_duration_seconds",
+		"soj_worker_judge_task_recovery_total",
+		"soj_worker_reconciliation_total",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("metrics body missing %s:\n%s", want, body)

--- a/internal/postgres/db/querier.go
+++ b/internal/postgres/db/querier.go
@@ -106,6 +106,7 @@ type Querier interface {
 	MarkSubmissionSystemError(ctx context.Context, arg MarkSubmissionSystemErrorParams) (Submission, error)
 	NextProblemStatementVersion(ctx context.Context, problemID int64) (int32, error)
 	NextTestcaseSetVersion(ctx context.Context, problemID int64) (int32, error)
+	RecoverDeadJudgeTask(ctx context.Context, arg RecoverDeadJudgeTaskParams) (JudgeTask, error)
 	ResetStaleJudgeTasks(ctx context.Context, arg ResetStaleJudgeTasksParams) ([]ResetStaleJudgeTasksRow, error)
 	RetryJudgeTask(ctx context.Context, arg RetryJudgeTaskParams) (JudgeTask, error)
 	RevokeRefreshToken(ctx context.Context, tokenHash string) error

--- a/internal/postgres/db/submissions.sql.go
+++ b/internal/postgres/db/submissions.sql.go
@@ -1604,6 +1604,60 @@ func (q *Queries) MarkJudgeTaskDead(ctx context.Context, arg MarkJudgeTaskDeadPa
 	return i, err
 }
 
+const recoverDeadJudgeTask = `-- name: RecoverDeadJudgeTask :one
+WITH recovered AS (
+    UPDATE judge_tasks
+    SET status = 'pending',
+        attempts = 0,
+        next_run_at = $1,
+        last_error = $2,
+        updated_at = now()
+    WHERE id = $3
+      AND status = 'dead'
+      AND EXISTS (
+          SELECT 1
+          FROM submissions
+          WHERE submissions.id = judge_tasks.submission_id
+            AND submissions.status = 'system_error'
+      )
+    RETURNING id, submission_id, stream_id, status, attempts, next_run_at, last_error, created_at, updated_at
+), recovered_submissions AS (
+    UPDATE submissions
+    SET status = 'queued',
+        error_message = $2,
+        judged_at = NULL,
+        updated_at = now()
+    FROM recovered
+    WHERE submissions.id = recovered.submission_id
+    RETURNING submissions.id
+)
+SELECT id, submission_id, stream_id, status, attempts, next_run_at, last_error, created_at, updated_at
+FROM recovered
+`
+
+type RecoverDeadJudgeTaskParams struct {
+	NextRunAt pgtype.Timestamptz `db:"next_run_at" json:"next_run_at"`
+	LastError pgtype.Text        `db:"last_error" json:"last_error"`
+	ID        int64              `db:"id" json:"id"`
+}
+
+func (q *Queries) RecoverDeadJudgeTask(ctx context.Context, arg RecoverDeadJudgeTaskParams) (JudgeTask, error) {
+	row := q.db.QueryRow(ctx, recoverDeadJudgeTask, arg.NextRunAt, arg.LastError, arg.ID)
+	var i JudgeTask
+	err := row.Scan(
+		&i.ID,
+		&i.SubmissionID,
+		&i.StreamID,
+		&i.Status,
+		&i.Attempts,
+		&i.NextRunAt,
+		&i.LastError,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const markJudgeTaskDispatched = `-- name: MarkJudgeTaskDispatched :one
 UPDATE judge_tasks
 SET status = CASE

--- a/internal/postgres/db/submissions_sql_test.go
+++ b/internal/postgres/db/submissions_sql_test.go
@@ -34,6 +34,24 @@ func TestResetStaleJudgeTasksSQLResetsTasksAndSubmissions(t *testing.T) {
 	}
 }
 
+func TestRecoverDeadJudgeTaskSQLQueuesOnlyDeadSystemErrorTasks(t *testing.T) {
+	for _, want := range []string{
+		"UPDATE judge_tasks",
+		"status = 'pending'",
+		"attempts = 0",
+		"WHERE id = $3",
+		"status = 'dead'",
+		"submissions.status = 'system_error'",
+		"UPDATE submissions",
+		"status = 'queued'",
+		"judged_at = NULL",
+	} {
+		if !strings.Contains(recoverDeadJudgeTask, want) {
+			t.Fatalf("RecoverDeadJudgeTask missing %q:\n%s", want, recoverDeadJudgeTask)
+		}
+	}
+}
+
 func TestJudgeTaskDispatchSQLHasStrictClaimAndMarkBoundaries(t *testing.T) {
 	for name, query := range map[string]string{
 		"ClaimPendingJudgeTasks":     claimPendingJudgeTasks,

--- a/internal/postgres/queries/submissions.sql
+++ b/internal/postgres/queries/submissions.sql
@@ -490,6 +490,36 @@ WHERE id = $1
   AND status IN ('dispatching', 'dispatched', 'running')
 RETURNING *;
 
+-- name: RecoverDeadJudgeTask :one
+WITH recovered AS (
+    UPDATE judge_tasks
+    SET status = 'pending',
+        attempts = 0,
+        next_run_at = sqlc.arg('next_run_at'),
+        last_error = sqlc.arg('last_error'),
+        updated_at = now()
+    WHERE id = sqlc.arg('id')
+      AND status = 'dead'
+      AND EXISTS (
+          SELECT 1
+          FROM submissions
+          WHERE submissions.id = judge_tasks.submission_id
+            AND submissions.status = 'system_error'
+      )
+    RETURNING *
+), recovered_submissions AS (
+    UPDATE submissions
+    SET status = 'queued',
+        error_message = sqlc.arg('last_error'),
+        judged_at = NULL,
+        updated_at = now()
+    FROM recovered
+    WHERE submissions.id = recovered.submission_id
+    RETURNING submissions.id
+)
+SELECT *
+FROM recovered;
+
 -- name: RetryJudgeTask :one
 UPDATE judge_tasks
 SET status = 'pending',

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -21,3 +21,14 @@ type TaskQueue interface {
 	DeadLetter(ctx context.Context, message Message, reason string) error
 	Close() error
 }
+
+type ReadinessChecker interface {
+	Ready(ctx context.Context) error
+}
+
+func CheckReady(ctx context.Context, queue TaskQueue) error {
+	if checker, ok := queue.(ReadinessChecker); ok {
+		return checker.Ready(ctx)
+	}
+	return nil
+}

--- a/internal/queue/redis_stream.go
+++ b/internal/queue/redis_stream.go
@@ -47,6 +47,17 @@ func (q *RedisStreamQueue) Ensure(ctx context.Context) error {
 	return err
 }
 
+func (q *RedisStreamQueue) Ready(ctx context.Context) error {
+	groups, err := q.client.XInfoGroups(ctx, q.cfg.Stream).Result()
+	if err != nil {
+		return err
+	}
+	if !redisStreamHasGroup(groups, q.cfg.Group) {
+		return fmt.Errorf("redis stream %s missing consumer group %s", q.cfg.Stream, q.cfg.Group)
+	}
+	return nil
+}
+
 func (q *RedisStreamQueue) Publish(ctx context.Context, taskID int64, payload []byte) (string, error) {
 	id, err := q.client.XAdd(ctx, &redis.XAddArgs{
 		Stream: q.cfg.Stream,
@@ -163,4 +174,13 @@ func xMessage(item redis.XMessage) (Message, error) {
 		Payload:  []byte(fmt.Sprint(item.Values["payload"])),
 		Attempts: attempts,
 	}, nil
+}
+
+func redisStreamHasGroup(groups []redis.XInfoGroup, name string) bool {
+	for _, group := range groups {
+		if group.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/queue/redis_stream_test.go
+++ b/internal/queue/redis_stream_test.go
@@ -29,3 +29,13 @@ func TestRedisMessageMappingPreservesPayloadAndAttempts(t *testing.T) {
 		t.Fatalf("message = %+v", msg)
 	}
 }
+
+func TestRedisStreamReadinessFindsConsumerGroup(t *testing.T) {
+	groups := []redis.XInfoGroup{{Name: "judge-workers"}, {Name: "other"}}
+	if !redisStreamHasGroup(groups, "judge-workers") {
+		t.Fatalf("redisStreamHasGroup returned false for existing group")
+	}
+	if redisStreamHasGroup(groups, "missing") {
+		t.Fatalf("redisStreamHasGroup returned true for missing group")
+	}
+}

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/url"
 	"strings"
@@ -131,6 +132,17 @@ func (s *S3Storage) Get(ctx context.Context, key string) (io.ReadCloser, ObjectI
 
 func (s *S3Storage) Delete(ctx context.Context, key string) error {
 	return s.client.RemoveObject(ctx, s.bucket, key, minio.RemoveObjectOptions{})
+}
+
+func (s *S3Storage) Ready(ctx context.Context) error {
+	exists, err := s.client.BucketExists(ctx, s.bucket)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("s3 bucket %s does not exist", s.bucket)
+	}
+	return err
 }
 
 func (s *S3Storage) Stat(ctx context.Context, key string) (ObjectInfo, error) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -28,3 +28,14 @@ type ObjectStorage interface {
 	Delete(ctx context.Context, key string) error
 	Stat(ctx context.Context, key string) (ObjectInfo, error)
 }
+
+type ReadinessChecker interface {
+	Ready(ctx context.Context) error
+}
+
+func CheckReady(ctx context.Context, store ObjectStorage) error {
+	if checker, ok := store.(ReadinessChecker); ok {
+		return checker.Ready(ctx)
+	}
+	return nil
+}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCheckReadyUsesOptionalReadinessChecker(t *testing.T) {
+	wantErr := errors.New("bucket unavailable")
+	store := &readyStore{err: wantErr}
+
+	err := CheckReady(context.Background(), store)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CheckReady error = %v, want %v", err, wantErr)
+	}
+	if !store.called {
+		t.Fatal("CheckReady did not call optional Ready method")
+	}
+}
+
+func TestCheckReadyPassesWhenStorageHasNoReadinessChecker(t *testing.T) {
+	if err := CheckReady(context.Background(), noReadyStore{}); err != nil {
+		t.Fatalf("CheckReady error = %v", err)
+	}
+}
+
+type readyStore struct {
+	noReadyStore
+	err    error
+	called bool
+}
+
+func (s *readyStore) Ready(context.Context) error {
+	s.called = true
+	return s.err
+}
+
+type noReadyStore struct{}
+
+func (noReadyStore) Put(context.Context, Object) (ObjectInfo, error) {
+	return ObjectInfo{}, nil
+}
+
+func (noReadyStore) Get(context.Context, string) (io.ReadCloser, ObjectInfo, error) {
+	return io.NopCloser(strings.NewReader("")), ObjectInfo{}, nil
+}
+
+func (noReadyStore) Delete(context.Context, string) error {
+	return nil
+}
+
+func (noReadyStore) Stat(context.Context, string) (ObjectInfo, error) {
+	return ObjectInfo{}, nil
+}

--- a/internal/submission/async_test.go
+++ b/internal/submission/async_test.go
@@ -237,6 +237,38 @@ func TestResultConsumerIsIdempotentAndAcksAfterPersist(t *testing.T) {
 	}
 }
 
+func TestRecoverDeadJudgeTaskResetsRetryBudgetAndQueuesSubmission(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemoryRepo()
+	repo.tasks[7] = JudgeTaskRecord{
+		ID:           7,
+		SubmissionID: 9,
+		Status:       "dead",
+		Attempts:     5,
+		LastError:    "runner image missing",
+	}
+	repo.submissions[9] = SubmissionRecord{ID: 9, Status: StatusSystemErr, ErrorMessage: stringPtr("runner image missing")}
+	nextRunAt := time.Unix(200, 0).UTC()
+
+	task, err := repo.RecoverDeadJudgeTask(ctx, 7, nextRunAt, "manual recovery after runner fix")
+	if err != nil {
+		t.Fatalf("RecoverDeadJudgeTask returned error: %v", err)
+	}
+	if task.Status != "pending" || task.Attempts != 0 || !task.NextRunAt.Equal(nextRunAt) {
+		t.Fatalf("task after recovery = %+v", task)
+	}
+	if task.LastError != "manual recovery after runner fix" {
+		t.Fatalf("last error = %q", task.LastError)
+	}
+	submission := repo.submissions[9]
+	if submission.Status != StatusQueued {
+		t.Fatalf("submission status = %q, want queued", submission.Status)
+	}
+	if submission.ErrorMessage == nil || *submission.ErrorMessage != "manual recovery after runner fix" {
+		t.Fatalf("submission error = %v", submission.ErrorMessage)
+	}
+}
+
 type recordingResultPublisher struct {
 	eventsPayloads [][]byte
 	events         *[]string

--- a/internal/submission/memory_repo_test.go
+++ b/internal/submission/memory_repo_test.go
@@ -389,6 +389,26 @@ func (r *memoryRepo) MarkJudgeTaskDead(ctx context.Context, id int64, reason str
 	r.events = append(r.events, "db_dead")
 	return row, nil
 }
+func (r *memoryRepo) RecoverDeadJudgeTask(ctx context.Context, id int64, nextRunAt time.Time, reason string) (JudgeTaskRecord, error) {
+	row := r.tasks[id]
+	if row.Status != "dead" {
+		return JudgeTaskRecord{}, fmt.Errorf("judge task %d is not dead", id)
+	}
+	submission := r.submissions[row.SubmissionID]
+	if submission.Status != StatusSystemErr {
+		return JudgeTaskRecord{}, fmt.Errorf("submission %d is not system_error", row.SubmissionID)
+	}
+	row.Status = "pending"
+	row.Attempts = 0
+	row.NextRunAt = nextRunAt
+	row.LastError = reason
+	r.tasks[id] = row
+	submission.Status = StatusQueued
+	submission.ErrorMessage = stringPtr(reason)
+	submission.JudgedAt = nil
+	r.submissions[row.SubmissionID] = submission
+	return row, nil
+}
 func (r *memoryRepo) CreateRun(ctx context.Context, arg RunRecord) (RunRecord, error) {
 	arg.ID = r.id()
 	r.runs[arg.ID] = arg

--- a/internal/submission/reconciler.go
+++ b/internal/submission/reconciler.go
@@ -6,45 +6,67 @@ import (
 )
 
 type Reconciler struct {
-	repo   Repository
-	worker *Worker
-	now    func() time.Time
+	repo    Repository
+	worker  *Worker
+	now     func() time.Time
+	metrics ReconcilerMetrics
 }
 
-func NewReconciler(repo Repository, worker *Worker, now func() time.Time) *Reconciler {
+type ReconcilerMetrics interface {
+	RecordReconcilerAction(action, result string, count int)
+}
+
+func NewReconciler(repo Repository, worker *Worker, now func() time.Time, metrics ...ReconcilerMetrics) *Reconciler {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &Reconciler{repo: repo, worker: worker, now: now}
+	var recorder ReconcilerMetrics
+	if len(metrics) > 0 {
+		recorder = metrics[0]
+	}
+	return &Reconciler{repo: repo, worker: worker, now: now, metrics: recorder}
 }
 
 func (r *Reconciler) ClaimStaleTasks(ctx context.Context, minIdle time.Duration, limit int) (int, error) {
 	messages, err := r.worker.queue.ClaimStale(ctx, minIdle, limit)
 	if err != nil {
+		r.record("claim_stale_tasks", "error", 1)
 		return 0, err
 	}
 	processed := 0
 	for _, message := range messages {
 		if err := r.worker.ProcessMessage(ctx, message); err != nil {
+			r.record("claim_stale_tasks", "error", 1)
 			return processed, err
 		}
 		processed++
 	}
+	r.record("claim_stale_tasks", "success", processed)
 	return processed, nil
 }
 
 func (r *Reconciler) MarkStaleRuns(ctx context.Context, maxAge time.Duration) (int, error) {
 	runs, err := r.repo.MarkStaleRunsSystemError(ctx, r.now().Add(-maxAge), "run reconciliation marked stale run as system_error")
 	if err != nil {
+		r.record("mark_stale_runs", "error", 1)
 		return 0, err
 	}
+	r.record("mark_stale_runs", "success", len(runs))
 	return len(runs), nil
 }
 
 func (r *Reconciler) ResetStaleTasks(ctx context.Context, maxAge time.Duration) (int, error) {
 	tasks, err := r.repo.ResetStaleJudgeTasks(ctx, r.now().Add(-maxAge), "judge task reconciliation reset stale task to pending")
 	if err != nil {
+		r.record("reset_stale_tasks", "error", 1)
 		return 0, err
 	}
+	r.record("reset_stale_tasks", "success", len(tasks))
 	return len(tasks), nil
+}
+
+func (r *Reconciler) record(action, result string, count int) {
+	if r.metrics != nil {
+		r.metrics.RecordReconcilerAction(action, result, count)
+	}
 }

--- a/internal/submission/repository.go
+++ b/internal/submission/repository.go
@@ -194,6 +194,7 @@ type Repository interface {
 	MarkJudgeTaskDone(ctx context.Context, id int64) (JudgeTaskRecord, error)
 	RetryJudgeTask(ctx context.Context, id int64, nextRunAt time.Time, reason string) (JudgeTaskRecord, error)
 	MarkJudgeTaskDead(ctx context.Context, id int64, reason string) (JudgeTaskRecord, error)
+	RecoverDeadJudgeTask(ctx context.Context, id int64, nextRunAt time.Time, reason string) (JudgeTaskRecord, error)
 	CreateRun(ctx context.Context, arg RunRecord) (RunRecord, error)
 	GetRun(ctx context.Context, id int64) (RunRecord, error)
 	UpdateRunStatus(ctx context.Context, id int64, result judge.Result) (RunRecord, error)
@@ -923,6 +924,11 @@ func (r *SQLRepository) RetryJudgeTask(ctx context.Context, id int64, nextRunAt 
 
 func (r *SQLRepository) MarkJudgeTaskDead(ctx context.Context, id int64, reason string) (JudgeTaskRecord, error) {
 	row, err := r.q.MarkJudgeTaskDead(ctx, db.MarkJudgeTaskDeadParams{ID: id, LastError: text(reason)})
+	return judgeTaskRecord(row), err
+}
+
+func (r *SQLRepository) RecoverDeadJudgeTask(ctx context.Context, id int64, nextRunAt time.Time, reason string) (JudgeTaskRecord, error) {
+	row, err := r.q.RecoverDeadJudgeTask(ctx, db.RecoverDeadJudgeTaskParams{NextRunAt: timestamptz(nextRunAt), LastError: text(reason), ID: id})
 	return judgeTaskRecord(row), err
 }
 

--- a/internal/submission/service_test.go
+++ b/internal/submission/service_test.go
@@ -307,7 +307,8 @@ func TestReconcilerResetsStaleJudgeTasks(t *testing.T) {
 	repo.tasks[1] = JudgeTaskRecord{ID: 1, SubmissionID: 11, Status: "dispatching"}
 	repo.tasks[2] = JudgeTaskRecord{ID: 2, SubmissionID: 12, Status: "running"}
 	repo.submissions[12] = SubmissionRecord{ID: 12, Status: StatusRunning}
-	reconciler := NewReconciler(repo, &Worker{queue: &memoryQueue{}}, func() time.Time { return now })
+	metrics := &recordingReconcilerMetrics{}
+	reconciler := NewReconciler(repo, &Worker{queue: &memoryQueue{}}, func() time.Time { return now }, metrics)
 
 	count, err := reconciler.ResetStaleTasks(context.Background(), time.Minute)
 	if err != nil {
@@ -315,6 +316,9 @@ func TestReconcilerResetsStaleJudgeTasks(t *testing.T) {
 	}
 	if count != 2 || repo.tasks[1].Status != "pending" || repo.tasks[2].Status != "pending" || repo.submissions[12].Status != StatusQueued {
 		t.Fatalf("count=%d task1=%+v task2=%+v submission=%+v", count, repo.tasks[1], repo.tasks[2], repo.submissions[12])
+	}
+	if !metrics.saw("reset_stale_tasks", "success", 2) {
+		t.Fatalf("reconciler metrics = %+v", metrics.records)
 	}
 }
 
@@ -827,4 +831,27 @@ func (m *recordingWorkerMetrics) RecordJudgeTaskDispatch(result string) {
 
 func (m *recordingWorkerMetrics) RecordJudgeTaskProcess(result string, duration time.Duration) {
 	m.processed = append(m.processed, recordedWorkerProcess{result: result, duration: duration})
+}
+
+type recordedReconcilerAction struct {
+	action string
+	result string
+	count  int
+}
+
+type recordingReconcilerMetrics struct {
+	records []recordedReconcilerAction
+}
+
+func (m *recordingReconcilerMetrics) RecordReconcilerAction(action, result string, count int) {
+	m.records = append(m.records, recordedReconcilerAction{action: action, result: result, count: count})
+}
+
+func (m *recordingReconcilerMetrics) saw(action, result string, count int) bool {
+	for _, record := range m.records {
+		if record.action == action && record.result == result && record.count == count {
+			return true
+		}
+	}
+	return false
 }

--- a/scripts/dev/check-docker-runner.sh
+++ b/scripts/dev/check-docker-runner.sh
@@ -12,13 +12,11 @@ need() {
   fi
 }
 
-runtime_args=()
 if [[ -n "$RUNTIME" ]]; then
   if ! docker info --format '{{json .Runtimes}}' | grep -q "\"$RUNTIME\""; then
     echo "docker runtime $RUNTIME is not registered" >&2
     exit 1
   fi
-  runtime_args=(--runtime "$RUNTIME")
 fi
 
 check_image() {
@@ -32,7 +30,11 @@ check_image() {
 
 check_noop() {
   local image="$1"
-  docker run --rm "${runtime_args[@]}" \
+  local docker_args=(run --rm)
+  if [[ -n "$RUNTIME" ]]; then
+    docker_args+=(--runtime "$RUNTIME")
+  fi
+  docker "${docker_args[@]}" \
     --network none \
     --read-only \
     --cap-drop ALL \

--- a/scripts/dev/runner-capacity-smoke.sh
+++ b/scripts/dev/runner-capacity-smoke.sh
@@ -75,7 +75,11 @@ api_json() {
 }
 
 now_ms() {
-  date +%s%3N
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import time; print(int(time.time() * 1000))'
+  else
+    printf '%s000\n' "$(date +%s)"
+  fi
 }
 
 percentile_file() {
@@ -293,15 +297,15 @@ where id in ($ids_csv);
 
 measure_container_startup() {
   local out_file="$1"
-  local runtime_args=()
+  local docker_args=(run --rm)
   local start end
   : > "$out_file"
   if [[ -n "$SOJ_DOCKER_RUNNER_RUNTIME" ]]; then
-    runtime_args=(--runtime "$SOJ_DOCKER_RUNNER_RUNTIME")
+    docker_args+=(--runtime "$SOJ_DOCKER_RUNNER_RUNTIME")
   fi
   for _ in $(seq 1 "$STARTUP_SAMPLES"); do
     start="$(now_ms)"
-    docker run --rm "${runtime_args[@]}" \
+    docker "${docker_args[@]}" \
       --network none \
       --read-only \
       --cap-drop ALL \
@@ -346,7 +350,10 @@ run_slot_benchmark() {
   done
   wait
 
-  mapfile -t ids < "$ids_file"
+  ids=()
+  while IFS= read -r id; do
+    ids+=("$id")
+  done < "$ids_file"
   if (( ${#ids[@]} != total )); then
     echo "created ${#ids[@]} submissions, want $total" >&2
     exit 1


### PR DESCRIPTION
## Summary

Adds the first Judge runtime production readiness slice: dependency-aware readiness probes, a dead-task recovery command, runtime metrics for readiness/reconciliation, and local validation/capacity documentation that can be linked from the README.

## What Changed

- Worker `/readyz` now checks PostgreSQL, Redis request/result streams, and object storage instead of only proving the process is alive.
- Judge-agent `/readyz` now checks Redis request/result streams, object storage, and the configured sandbox backend probe.
- Added `soj-worker recover-dead-task -task-id <id> [-reason <text>]` to replay a dead judge task through PostgreSQL as the source of truth.
- Added readiness/reconciliation metrics and tests around the new behavior.
- Fixed local runner validation scripts for macOS bash compatibility discovered while running capacity smoke.
- Added `docs/judge-runtime-readiness.md` and `docs/runner-capacity-report-2026-07-06.md`, then linked them from README and deploy docs.

## Validation

- `go test ./...`
- `go vet ./...`
- `docker compose -f deploy/docker-compose.yaml config`
- `make compose-config-docker-runner`
- `bash -n scripts/dev/check-docker-runner.sh scripts/dev/runner-capacity-smoke.sh`
- `RUNNER_IMAGES_PREPARE=skip SOJ_CAPACITY_SKIP_BUILD=1 make smoke-real-docker`
- `RUNNER_IMAGES_PREPARE=skip SOJ_CAPACITY_SKIP_BUILD=1 make smoke-runner-capacity`
- `/readyz` checked for API, worker, and judge-agent on the running local Docker stack
- worker `/metrics` checked for `soj_readiness_checks_total` and `soj_worker_reconciliation_total`

## Capacity Note

runsc capacity could not be executed on the local machine because Docker does not have the `runsc` runtime registered. The report records that blocker and includes a successful default Docker runtime comparison across `1/2/4/8/16` judge-agent slots. That comparison is explicitly non-production evidence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT_5-000000)