### PR TITLE
ci: add docker smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,32 @@ jobs:
 
       - name: Build migrate image
         run: docker build -f Dockerfile.v2 --build-arg COMMAND=soj-migrate -t soj-migrate:ci .
+
+  smoke:
+    name: Docker Smoke
+    runs-on: ubuntu-latest
+    needs: backend
+    timeout-minutes: 20
+    env:
+      COMPOSE_PROJECT_NAME: soj-ci-smoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start smoke stack
+        run: |
+          docker compose -f deploy/docker-compose.yaml down -v --remove-orphans
+          docker compose -f deploy/docker-compose.yaml up --build -d
+
+      - name: Run smoke test
+        run: ./deploy/smoke.sh
+
+      - name: Dump smoke logs on failure
+        if: failure()
+        run: |
+          docker compose -f deploy/docker-compose.yaml ps || true
+          docker compose -f deploy/docker-compose.yaml logs --no-color api worker judge-agent migrate seed postgres redis minio prometheus || true
+
+      - name: Stop smoke stack
+        if: always()
+        run: docker compose -f deploy/docker-compose.yaml down -v --remove-orphans || true


### PR DESCRIPTION
## Summary

Adds a dedicated Docker Smoke GitHub Actions job that runs after the backend job. The smoke job boots the local Docker Compose stack, runs `deploy/smoke.sh`, dumps key service logs on failure, and always tears the stack down.

This turns the existing API + worker + judge-agent + PostgreSQL + Redis + MinIO smoke path into a PR/release gate instead of leaving it as a manual-only check.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow-yaml-ok"'`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `docker compose -f deploy/docker-compose.yaml config`
- `COMPOSE_FILE=deploy/docker-compose.yaml:deploy/docker-compose.docker-runner.yaml docker compose config`

Local full Docker smoke was attempted. Image build completed after pulling `golang:1.25-alpine`, but stack startup was blocked by an existing local SOJ Compose stack already bound to the default ports (`5432`, `6379`, `8080`-`8082`, `9000`-`9001`, `9090`). I did not stop that existing stack; this PR's new GitHub Actions job will run the same smoke path on a clean runner.

## Post-Deploy Monitoring & Validation

No production runtime monitoring required. This change only adds CI workflow coverage and does not change deployed application behavior.

Validation owner: PR author. Validation window: this PR's GitHub Actions run before merge.

Healthy signal: `Backend` and `Docker Smoke` checks pass on the PR.
Failure signal: `Docker Smoke` fails; inspect the workflow's dumped `api`, `worker`, `judge-agent`, `migrate`, `seed`, `postgres`, `redis`, `minio`, and `prometheus` logs.
Mitigation: fix the failing service or smoke step and rerun the PR checks before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT_5-000000)