### PR TITLE
feat(problem): expose testcase validation checks

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -332,6 +332,51 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "422": { $ref: "#/components/responses/ValidationFailed" }
         "500": { $ref: "#/components/responses/InternalError" }
+  /api/v1/problems/{id}/checks:
+    post:
+      tags: [Problems]
+      operationId: runProblemCheck
+      summary: Run a synchronous problem data check
+      x-owner: WP3 Problem
+      x-auth: owner-admin-root
+      parameters:
+        - $ref: "#/components/parameters/ID"
+      responses:
+        "201":
+          description: Problem check run completed or failed synchronously.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemCheckRunEnvelope"
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthenticated" }
+        "403": { $ref: "#/components/responses/PermissionDenied" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/ServiceUnavailable" }
+        "500": { $ref: "#/components/responses/InternalError" }
+  /api/v1/problems/{id}/checks/{check_id}:
+    get:
+      tags: [Problems]
+      operationId: getProblemCheck
+      summary: Get a problem check run
+      x-owner: WP3 Problem
+      x-auth: owner-admin-root
+      parameters:
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/ProblemCheckID"
+      responses:
+        "200":
+          description: Problem check run and findings.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemCheckRunEnvelope"
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthenticated" }
+        "403": { $ref: "#/components/responses/PermissionDenied" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "503": { $ref: "#/components/responses/ServiceUnavailable" }
+        "500": { $ref: "#/components/responses/InternalError" }
   /api/v1/problems/{id}/stats:
     get:
       tags: [Problems]
@@ -822,6 +867,14 @@ components:
       schema:
         type: integer
         format: int64
+    ProblemCheckID:
+      x-owner: WP3 Problem
+      name: check_id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
     Page:
       x-owner: WP1 Data/API Contract
       name: page
@@ -864,6 +917,10 @@ components:
       x-owner: WP1 Data/API Contract
       description: Validation failed.
       content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+    ServiceUnavailable:
+      x-owner: WP1 Data/API Contract
+      description: Service unavailable.
+      content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
     InternalError:
       x-owner: WP1 Data/API Contract
       description: Internal error.
@@ -905,13 +962,18 @@ components:
             - route.not_found
             - validation.failed
             - auth.invalid_credentials
+            - auth.required
             - auth.token_expired
             - auth.refresh_token_revoked
             - user.email_exists
+            - problem.id_invalid
+            - problem.forbidden
             - problem.not_found
             - problem.slug_conflict
             - problem.not_publishable
             - problem.testcase_not_ready
+            - problem_check.id_invalid
+            - problem_check.not_found
             - testcase.invalid_archive
             - submission.not_found
             - submission.not_allowed
@@ -954,6 +1016,12 @@ components:
     TestcaseSetStatus:
       type: string
       enum: [uploading, ready, disabled]
+    ProblemCheckStatus:
+      type: string
+      enum: [queued, running, completed, failed, canceled]
+    ProblemCheckSeverity:
+      type: string
+      enum: [info, warning, error]
     JudgeStatus:
       type: string
       enum: [queued, running, accepted, wrong_answer, compile_error, runtime_error, time_limit, memory_limit, system_error, canceled]
@@ -1120,6 +1188,88 @@ components:
         status: { $ref: "#/components/schemas/TestcaseSetStatus" }
         is_current: { type: boolean }
         created_at: { type: string, format: date-time }
+    ProblemCheckSummary:
+      type: object
+      required: [case_count, expected_case_count, finding_count, error_count, warning_count, info_count, storage_readable, zip_readable, valid]
+      properties:
+        case_count:
+          type: integer
+          description: Number of input/output pairs found in the archive.
+        expected_case_count:
+          type: integer
+          description: Case count declared by the current testcase set.
+        finding_count:
+          type: integer
+          minimum: 0
+        error_count:
+          type: integer
+          minimum: 0
+        warning_count:
+          type: integer
+          minimum: 0
+        info_count:
+          type: integer
+          minimum: 0
+        storage_readable:
+          type: boolean
+          description: Whether the current testcase archive object was readable.
+        zip_readable:
+          type: boolean
+          description: Whether the current testcase archive was parseable as zip.
+        valid:
+          type: boolean
+          description: True when the completed check produced no error findings.
+    ProblemCheckFinding:
+      type: object
+      required: [id, run_id, severity, code, message, details, created_at]
+      properties:
+        id: { type: integer, format: int64 }
+        run_id: { type: integer, format: int64 }
+        severity: { $ref: "#/components/schemas/ProblemCheckSeverity" }
+        code:
+          type: string
+          description: Stable machine-readable finding code.
+        message:
+          type: string
+          description: Human-readable finding summary.
+        case_index:
+          type: integer
+          nullable: true
+          description: 1-based testcase index when the finding belongs to a specific case.
+        testcase_key:
+          type: string
+          nullable: true
+          description: Testcase archive member or logical key when available.
+        details:
+          type: object
+          additionalProperties: true
+        created_at: { type: string, format: date-time }
+    ProblemCheckRun:
+      type: object
+      required: [id, problem_id, status, summary, findings, created_at, updated_at]
+      properties:
+        id: { type: integer, format: int64 }
+        problem_id: { type: integer, format: int64 }
+        testcase_set_id:
+          type: integer
+          format: int64
+          nullable: true
+        requested_by:
+          type: integer
+          format: int64
+          nullable: true
+        status: { $ref: "#/components/schemas/ProblemCheckStatus" }
+        summary: { $ref: "#/components/schemas/ProblemCheckSummary" }
+        error_message:
+          type: string
+          nullable: true
+        findings:
+          type: array
+          items: { $ref: "#/components/schemas/ProblemCheckFinding" }
+        started_at: { type: string, format: date-time, nullable: true }
+        finished_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
     SubmissionCreateRequest:
       type: object
       required: [problem_id, language_id, source_code]
@@ -1440,6 +1590,9 @@ components:
     TestcaseSetEnvelope:
       allOf: [{ $ref: "#/components/schemas/Envelope" }]
       properties: { data: { $ref: "#/components/schemas/TestcaseSetResponse" } }
+    ProblemCheckRunEnvelope:
+      allOf: [{ $ref: "#/components/schemas/Envelope" }]
+      properties: { data: { $ref: "#/components/schemas/ProblemCheckRun" } }
     ProblemStatsEnvelope:
       allOf: [{ $ref: "#/components/schemas/Envelope" }]
       properties: { data: { $ref: "#/components/schemas/ProblemStatsResponse" } }

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -38,7 +38,8 @@ wait_http() {
 require_metric() {
   local url="$1"
   local metric="$2"
-  if ! curl -fsS "$url/metrics" | grep -q "$metric"; then
+  local body
+  if ! body="$(curl -fsS "$url/metrics")" || ! grep -q "$metric" <<<"$body"; then
     echo "metric $metric was not found at $url/metrics" >&2
     exit 1
   fi

--- a/docs/superpowers/plans/2026-07-10-problem-check-validation.md
+++ b/docs/superpowers/plans/2026-07-10-problem-check-validation.md
@@ -1,0 +1,76 @@
+# Problem Check Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a synchronous problem data validation MVP for the current testcase archive.
+
+**Architecture:** Keep validation in `internal/problem` behind the existing service/repository/handler boundaries. Reuse existing `problem_check_runs` and `problem_check_findings` tables; do not add migrations for this slice. Return persisted run + findings through REST endpoints and OpenAPI.
+
+**Tech Stack:** Go 1.25, Gin, PostgreSQL/sqlc, existing object storage abstraction, OpenAPI YAML.
+
+**Status:** Completed on 2026-07-10.
+
+---
+
+## Scope
+
+- Add `POST /api/v1/problems/{id}/checks` to run validation on the current ready testcase set.
+- Add `GET /api/v1/problems/{id}/checks/{check_id}` to fetch a run and findings.
+- Validate storage readability, zip parseability, input/output pairing, expected case count, empty archives, and statement sample JSON consistency.
+- Persist one completed or failed check run plus findings.
+- Keep checks synchronous for MVP; no worker queue, no background retries, no new migration.
+
+## Parallel Work Slices
+
+### Task 1: Service Validation
+
+**Files:**
+- Modify: `internal/problem/service.go`
+- Modify: `internal/problem/service_test.go`
+
+- [x] Add check run, finding, summary response types.
+- [x] Add service method `RunProblemCheck(ctx, actor, problemID)` with owner/admin authorization.
+- [x] Load current problem, current statement, current ready testcase set, and object storage bytes.
+- [x] Produce findings for unreadable storage, invalid zip, missing pairs, case count mismatch, empty archive, and invalid statement samples.
+- [x] Persist run and findings through repository methods.
+- [x] Add focused service tests that first fail, then pass.
+
+### Task 2: Repository Wiring
+
+**Files:**
+- Modify: `internal/problem/repository.go`
+- Modify: `internal/problem/service_test.go`
+- Regenerate/check: `internal/postgres/db/problems.sql.go`, `internal/postgres/db/querier.go` only if sqlc output requires it.
+
+- [x] Extend `Repository` with create/get/list methods for check runs and findings.
+- [x] Map DB rows to domain structs, including JSON summary/details and nullable fields.
+- [x] Implement fake repository support for service tests.
+- [x] Verify existing sqlc queries are sufficient before changing SQL.
+
+### Task 3: HTTP And Contract
+
+**Files:**
+- Modify: `internal/problem/handler.go`
+- Modify: `internal/problem/routes.go`
+- Modify: `api/openapi.yaml`
+- Modify: `docs/v2-api-guide.md`
+- Optional test: add/extend handler or service tests if an existing HTTP test pattern is present.
+
+- [x] Add route handlers for run and get check endpoints.
+- [x] Parse `check_id`, return envelopes, and preserve existing error handling.
+- [x] Add OpenAPI paths and schemas for `ProblemCheckRun`, `ProblemCheckFinding`, and envelope.
+- [x] Document the endpoints in the API guide.
+
+## Verification
+
+- [x] `go test ./internal/problem`
+- [x] `go test ./internal/postgres/db`
+- [x] `go test ./...`
+- [x] `go vet ./...`
+- [x] `git diff --check`
+
+## PR
+
+- Branch: `feat/problem-check-validation`
+- Commit message target: `feat(problem): expose testcase validation checks`
+- PR base: `main`

--- a/docs/v2-api-guide.md
+++ b/docs/v2-api-guide.md
@@ -6,7 +6,7 @@ This guide summarizes the WP1 contract baseline in `api/openapi.yaml`.
 
 - WP1 owns shared schemas, response envelopes, pagination, error responses, and this guide.
 - WP2 owns auth paths and admin user paths.
-- WP3 owns problem, statement, testcase-set, and problem stats paths.
+- WP3 owns problem, statement, testcase-set, problem check, and problem stats paths.
 - WP4 owns submission, run, and admin language paths.
 - WP5 owns contest, registration, and scoreboard paths.
 
@@ -75,7 +75,17 @@ Problems:
 - `DELETE /api/v1/problems/{id}`
 - `POST /api/v1/problems/{id}/statement`
 - `POST /api/v1/problems/{id}/testcase-sets`
+- `POST /api/v1/problems/{id}/checks`
+- `GET /api/v1/problems/{id}/checks/{check_id}`
 - `GET /api/v1/problems/{id}/stats`
+
+Problem checks:
+
+- `POST /api/v1/problems/{id}/checks` synchronously validates the current ready testcase set for the problem. The response is a `201` envelope whose `data` is a `ProblemCheckRun`.
+- `GET /api/v1/problems/{id}/checks/{check_id}` returns the persisted check run and its findings in a `200` envelope.
+- Check endpoints are owner/admin/root scoped. They use the same error envelope as the rest of the API.
+- `ProblemCheckRun.summary` includes archive counts, finding counts by severity, storage/zip readability flags, and `valid`.
+- `ProblemCheckRun.findings` contains stable finding `code`, `severity`, `message`, optional `case_index` and `testcase_key`, and structured `details`.
 
 Submissions and runs:
 

--- a/internal/judgecore/core_test.go
+++ b/internal/judgecore/core_test.go
@@ -11,7 +11,7 @@ import (
 	"SOJ/internal/judgecore/language"
 )
 
-const normalCaseTimeLimit = 3 * time.Second
+const normalCaseTimeLimit = 10 * time.Second
 
 func TestCoreJudgesGoAccepted(t *testing.T) {
 	result := judgeGo(t, `package main

--- a/internal/problem/handler.go
+++ b/internal/problem/handler.go
@@ -1,6 +1,7 @@
 package problem
 
 import (
+	"context"
 	"io"
 	"strconv"
 
@@ -12,11 +13,26 @@ import (
 )
 
 type Handler struct {
-	service *Service
+	service     *Service
+	checkRunner problemCheckRunner
+	checkGetter problemCheckGetter
 }
 
 func NewHandler(service *Service) *Handler {
-	return &Handler{service: service}
+	handler := &Handler{service: service}
+	if service != nil {
+		handler.checkRunner, _ = any(service).(problemCheckRunner)
+		handler.checkGetter, _ = any(service).(problemCheckGetter)
+	}
+	return handler
+}
+
+type problemCheckRunner interface {
+	RunProblemCheck(ctx context.Context, actor auth.Actor, problemID int64) (ProblemCheckResult, error)
+}
+
+type problemCheckGetter interface {
+	GetProblemCheck(ctx context.Context, actor auth.Actor, problemID int64, checkID int64) (ProblemCheckResult, error)
 }
 
 func (h *Handler) createProblem(c *gin.Context) {
@@ -206,6 +222,78 @@ func (h *Handler) uploadTestcases(c *gin.Context) {
 	httpapi.Created(c, set)
 }
 
+func (h *Handler) runProblemCheck(c *gin.Context) {
+	id, ok := problemIDParam(c)
+	if !ok {
+		return
+	}
+	service, ok := h.problemCheckRunner()
+	if !ok {
+		httpapi.Error(c, apperror.ServiceUnavailable("problem checks are not available"))
+		return
+	}
+	result, err := service.RunProblemCheck(c.Request.Context(), actorFromContext(c), id)
+	if err != nil {
+		httpapi.Error(c, err)
+		return
+	}
+	httpapi.Created(c, problemCheckRunResponse(result))
+}
+
+func (h *Handler) getProblemCheck(c *gin.Context) {
+	id, ok := problemIDParam(c)
+	if !ok {
+		return
+	}
+	checkID, ok := problemCheckIDParam(c)
+	if !ok {
+		return
+	}
+	service, ok := h.problemCheckGetter()
+	if !ok {
+		httpapi.Error(c, apperror.ServiceUnavailable("problem checks are not available"))
+		return
+	}
+	result, err := service.GetProblemCheck(c.Request.Context(), actorFromContext(c), id, checkID)
+	if err != nil {
+		httpapi.Error(c, err)
+		return
+	}
+	httpapi.OK(c, problemCheckRunResponse(result))
+}
+
+func (h *Handler) problemCheckRunner() (problemCheckRunner, bool) {
+	if h.checkRunner != nil {
+		return h.checkRunner, true
+	}
+	if h.service == nil {
+		return nil, false
+	}
+	service, ok := any(h.service).(problemCheckRunner)
+	return service, ok
+}
+
+func (h *Handler) problemCheckGetter() (problemCheckGetter, bool) {
+	if h.checkGetter != nil {
+		return h.checkGetter, true
+	}
+	if h.service == nil {
+		return nil, false
+	}
+	service, ok := any(h.service).(problemCheckGetter)
+	return service, ok
+}
+
+func problemCheckRunResponse(result ProblemCheckResult) ProblemCheckRun {
+	run := result.Run
+	if result.Findings == nil {
+		run.Findings = []ProblemCheckFinding{}
+	} else {
+		run.Findings = result.Findings
+	}
+	return run
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
 		if value != "" {
@@ -232,6 +320,15 @@ func problemIDParam(c *gin.Context) (int64, bool) {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil || id <= 0 {
 		httpapi.Error(c, apperror.BadRequest("problem.id_invalid", "problem id is invalid"))
+		return 0, false
+	}
+	return id, true
+}
+
+func problemCheckIDParam(c *gin.Context) (int64, bool) {
+	id, err := strconv.ParseInt(c.Param("check_id"), 10, 64)
+	if err != nil || id <= 0 {
+		httpapi.Error(c, apperror.BadRequest("problem_check.id_invalid", "problem check id is invalid"))
 		return 0, false
 	}
 	return id, true

--- a/internal/problem/handler_test.go
+++ b/internal/problem/handler_test.go
@@ -1,14 +1,149 @@
 package problem
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"SOJ/internal/auth"
 	"SOJ/internal/httpapi"
 )
+
+func TestRunProblemCheckReturnsCreatedEnvelope(t *testing.T) {
+	startedAt := time.Date(2026, 7, 10, 9, 30, 0, 0, time.UTC)
+	checks := &fakeProblemCheckService{
+		result: ProblemCheckResult{
+			Run: ProblemCheckRun{
+				ID:            99,
+				ProblemID:     1,
+				TestcaseSetID: 7,
+				RequestedBy:   10,
+				Status:        "completed",
+				Summary: ProblemCheckSummary{
+					CaseCount:    2,
+					FindingCount: 1,
+					WarningCount: 1,
+					Valid:        false,
+				},
+				StartedAt:  startedAt,
+				FinishedAt: startedAt,
+				CreatedAt:  startedAt,
+				UpdatedAt:  startedAt,
+			},
+			Findings: []ProblemCheckFinding{{
+				ID:        5,
+				RunID:     99,
+				Severity:  "warning",
+				Code:      "statement.sample_output_empty",
+				Message:   "sample output is empty",
+				CaseIndex: 1,
+				Details:   json.RawMessage(`{"field":"samples[0].output"}`),
+				CreatedAt: startedAt,
+			}},
+		},
+	}
+	service := &Service{}
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
+		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/problems/1/checks", nil)
+	req.Header.Set("X-User-ID", "10")
+	req.Header.Set("X-User-Role", "user")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	if checks.runProblemID != 1 || checks.runActor.UserID != 10 {
+		t.Fatalf("RunProblemCheck args problemID=%d actor=%+v", checks.runProblemID, checks.runActor)
+	}
+	var envelope struct {
+		Data  ProblemCheckRun    `json:"data"`
+		Error *httpapi.ErrorBody `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Error != nil {
+		t.Fatalf("unexpected error body: %+v", envelope.Error)
+	}
+	if envelope.Data.ID != 99 || envelope.Data.Summary.WarningCount != 1 || len(envelope.Data.Findings) != 1 {
+		t.Fatalf("unexpected data: %+v", envelope.Data)
+	}
+}
+
+func TestGetProblemCheckParsesCheckIDAndReturnsEnvelope(t *testing.T) {
+	createdAt := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	checks := &fakeProblemCheckService{
+		result: ProblemCheckResult{
+			Run: ProblemCheckRun{
+				ID:        99,
+				ProblemID: 1,
+				Status:    "completed",
+				Summary:   ProblemCheckSummary{CaseCount: 2, Valid: true},
+				CreatedAt: createdAt,
+				UpdatedAt: createdAt,
+			},
+			Findings: []ProblemCheckFinding{},
+		},
+	}
+	service := &Service{}
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
+		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems/1/checks/99", nil)
+	req.Header.Set("X-User-ID", "10")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if checks.getProblemID != 1 || checks.getCheckID != 99 {
+		t.Fatalf("GetProblemCheck args problemID=%d checkID=%d", checks.getProblemID, checks.getCheckID)
+	}
+	var envelope struct {
+		Data ProblemCheckRun `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if envelope.Data.Findings == nil || len(envelope.Data.Findings) != 0 {
+		t.Fatalf("findings = %#v, want empty array", envelope.Data.Findings)
+	}
+}
+
+func TestGetProblemCheckRejectsInvalidCheckID(t *testing.T) {
+	checks := &fakeProblemCheckService{}
+	service := &Service{}
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
+		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
+	}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems/1/checks/not-a-number", nil)
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"problem_check.id_invalid"`) {
+		t.Fatalf("body missing problem_check.id_invalid: %s", rec.Body.String())
+	}
+	if checks.getCheckID != 0 {
+		t.Fatalf("GetProblemCheck should not be called for invalid check_id")
+	}
+}
 
 func TestUploadTestcasesMissingArchiveReturnsTestcaseNotReady(t *testing.T) {
 	repo := newFakeRepository()
@@ -55,4 +190,27 @@ func TestCreateProblemStoresTags(t *testing.T) {
 	if len(response.Tags) != 2 || response.Tags[0] != "Array" || response.Tags[1] != "Hash Table" {
 		t.Fatalf("tags = %v", response.Tags)
 	}
+}
+
+type fakeProblemCheckService struct {
+	result       ProblemCheckResult
+	err          error
+	runProblemID int64
+	getProblemID int64
+	getCheckID   int64
+	runActor     auth.Actor
+	getActor     auth.Actor
+}
+
+func (s *fakeProblemCheckService) RunProblemCheck(ctx context.Context, actor auth.Actor, problemID int64) (ProblemCheckResult, error) {
+	s.runActor = actor
+	s.runProblemID = problemID
+	return s.result, s.err
+}
+
+func (s *fakeProblemCheckService) GetProblemCheck(ctx context.Context, actor auth.Actor, problemID int64, checkID int64) (ProblemCheckResult, error) {
+	s.getActor = actor
+	s.getProblemID = problemID
+	s.getCheckID = checkID
+	return s.result, s.err
 }

--- a/internal/problem/repository.go
+++ b/internal/problem/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"time"
 
 	"SOJ/internal/apperror"
 	"SOJ/internal/postgres"
@@ -35,8 +36,79 @@ type Repository interface {
 	ClearCurrentTestcaseSet(ctx context.Context, problemID int64) error
 	CreateTestcaseSet(ctx context.Context, problemID int64, version int32, storageKey, checksum string, sizeBytes int64, caseCount int32, createdBy int64) (TestcaseSetRecord, error)
 	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
+	CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error)
+	GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error)
+	ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error)
+	CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error)
+	FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error)
+	CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error)
+	GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error)
+	ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error)
 	CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error)
 	GetProblemStats(ctx context.Context, problemID int64) (ProblemStats, error)
+}
+
+type CreateProblemCheckRunInput struct {
+	ProblemID     int64
+	TestcaseSetID int64
+	RequestedBy   int64
+	Status        string
+	Summary       json.RawMessage
+}
+
+type ListProblemCheckRunsFilter struct {
+	ProblemID int64
+	Offset    int32
+	Limit     int32
+}
+
+type CompleteProblemCheckRunInput struct {
+	ID         int64
+	Summary    json.RawMessage
+	FinishedAt time.Time
+}
+
+type FailProblemCheckRunInput struct {
+	ID           int64
+	Summary      json.RawMessage
+	ErrorMessage string
+	FinishedAt   time.Time
+}
+
+type CreateProblemCheckFindingInput struct {
+	RunID       int64
+	Severity    string
+	Code        string
+	Message     string
+	CaseIndex   int32
+	TestcaseKey string
+	Details     json.RawMessage
+}
+
+type ProblemCheckRunRecord struct {
+	ID            int64           `json:"id"`
+	ProblemID     int64           `json:"problem_id"`
+	TestcaseSetID int64           `json:"testcase_set_id,omitempty"`
+	RequestedBy   int64           `json:"requested_by,omitempty"`
+	Status        string          `json:"status"`
+	Summary       json.RawMessage `json:"summary"`
+	ErrorMessage  string          `json:"error_message,omitempty"`
+	StartedAt     time.Time       `json:"started_at,omitempty"`
+	FinishedAt    time.Time       `json:"finished_at,omitempty"`
+	CreatedAt     time.Time       `json:"created_at,omitempty"`
+	UpdatedAt     time.Time       `json:"updated_at,omitempty"`
+}
+
+type ProblemCheckFindingRecord struct {
+	ID          int64           `json:"id"`
+	RunID       int64           `json:"run_id"`
+	Severity    string          `json:"severity"`
+	Code        string          `json:"code"`
+	Message     string          `json:"message"`
+	CaseIndex   int32           `json:"case_index,omitempty"`
+	TestcaseKey string          `json:"testcase_key,omitempty"`
+	Details     json.RawMessage `json:"details"`
+	CreatedAt   time.Time       `json:"created_at,omitempty"`
 }
 
 type PostgresRepository struct {
@@ -164,6 +236,40 @@ func (r *PostgresRepository) CreateTestcaseSet(ctx context.Context, problemID in
 func (r *PostgresRepository) GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error) {
 	set, err := r.queries.GetCurrentReadyTestcaseSet(ctx, problemID)
 	return testcaseSetFromDB(set), mapDBErr(err)
+}
+
+func (r *PostgresRepository) CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return createProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *PostgresRepository) GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error) {
+	run, err := r.queries.GetProblemCheckRunByID(ctx, id)
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func (r *PostgresRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
+	return listProblemCheckRuns(ctx, r.queries, filter)
+}
+
+func (r *PostgresRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return completeProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *PostgresRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return failProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *PostgresRepository) CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
+	return createProblemCheckFinding(ctx, r.queries, input)
+}
+
+func (r *PostgresRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
+	finding, err := r.queries.GetProblemCheckFindingByID(ctx, id)
+	return problemCheckFindingFromDB(finding), mapDBErr(err)
+}
+
+func (r *PostgresRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {
+	return listProblemCheckFindings(ctx, r.queries, runID)
 }
 
 func (r *PostgresRepository) CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error) {
@@ -295,6 +401,40 @@ func (r *txRepository) GetCurrentReadyTestcaseSet(ctx context.Context, problemID
 	return testcaseSetFromDB(set), mapDBErr(err)
 }
 
+func (r *txRepository) CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return createProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *txRepository) GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error) {
+	run, err := r.queries.GetProblemCheckRunByID(ctx, id)
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func (r *txRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
+	return listProblemCheckRuns(ctx, r.queries, filter)
+}
+
+func (r *txRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return completeProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *txRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return failProblemCheckRun(ctx, r.queries, input)
+}
+
+func (r *txRepository) CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
+	return createProblemCheckFinding(ctx, r.queries, input)
+}
+
+func (r *txRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
+	finding, err := r.queries.GetProblemCheckFindingByID(ctx, id)
+	return problemCheckFindingFromDB(finding), mapDBErr(err)
+}
+
+func (r *txRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {
+	return listProblemCheckFindings(ctx, r.queries, runID)
+}
+
 func (r *txRepository) CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error) {
 	return createArtifact(ctx, r.queries, artifact)
 }
@@ -381,6 +521,81 @@ func createTestcaseSet(ctx context.Context, q *db.Queries, problemID int64, vers
 		CreatedBy:      createdBy,
 	})
 	return testcaseSetFromDB(set), mapDBErr(err)
+}
+
+func createProblemCheckRun(ctx context.Context, q *db.Queries, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	status := input.Status
+	if status == "" {
+		status = ProblemCheckStatusQueued
+	}
+	run, err := q.CreateProblemCheckRun(ctx, db.CreateProblemCheckRunParams{
+		ProblemID:     input.ProblemID,
+		TestcaseSetID: int8Value(input.TestcaseSetID),
+		RequestedBy:   int8Value(input.RequestedBy),
+		Status:        status,
+		Summary:       jsonbArg(input.Summary),
+	})
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func listProblemCheckRuns(ctx context.Context, q *db.Queries, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
+	rows, err := q.ListProblemCheckRunsByProblemID(ctx, db.ListProblemCheckRunsByProblemIDParams{
+		ProblemID: filter.ProblemID,
+		Offset:    filter.Offset,
+		Limit:     filter.Limit,
+	})
+	if err != nil {
+		return nil, mapDBErr(err)
+	}
+	runs := make([]ProblemCheckRunRecord, 0, len(rows))
+	for _, row := range rows {
+		runs = append(runs, problemCheckRunFromDB(row))
+	}
+	return runs, nil
+}
+
+func completeProblemCheckRun(ctx context.Context, q *db.Queries, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	run, err := q.CompleteProblemCheckRun(ctx, db.CompleteProblemCheckRunParams{
+		ID:         input.ID,
+		Summary:    jsonbArg(input.Summary),
+		FinishedAt: timeArg(input.FinishedAt),
+	})
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func failProblemCheckRun(ctx context.Context, q *db.Queries, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	run, err := q.FailProblemCheckRun(ctx, db.FailProblemCheckRunParams{
+		ID:           input.ID,
+		Summary:      jsonbArg(input.Summary),
+		ErrorMessage: textValue(input.ErrorMessage),
+		FinishedAt:   timeArg(input.FinishedAt),
+	})
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func createProblemCheckFinding(ctx context.Context, q *db.Queries, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
+	finding, err := q.CreateProblemCheckFinding(ctx, db.CreateProblemCheckFindingParams{
+		RunID:       input.RunID,
+		Severity:    input.Severity,
+		Code:        input.Code,
+		Message:     input.Message,
+		CaseIndex:   int4Value(input.CaseIndex),
+		TestcaseKey: textValue(input.TestcaseKey),
+		Details:     jsonbArg(input.Details),
+	})
+	return problemCheckFindingFromDB(finding), mapDBErr(err)
+}
+
+func listProblemCheckFindings(ctx context.Context, q *db.Queries, runID int64) ([]ProblemCheckFindingRecord, error) {
+	rows, err := q.ListProblemCheckFindingsByRunID(ctx, runID)
+	if err != nil {
+		return nil, mapDBErr(err)
+	}
+	findings := make([]ProblemCheckFindingRecord, 0, len(rows))
+	for _, row := range rows {
+		findings = append(findings, problemCheckFindingFromDB(row))
+	}
+	return findings, nil
 }
 
 func createArtifact(ctx context.Context, q *db.Queries, artifact ArtifactRecord) (ArtifactRecord, error) {
@@ -510,6 +725,70 @@ func testcaseSetFromDB(set db.TestcaseSet) TestcaseSetRecord {
 	}
 }
 
+func problemCheckRunFromDB(run db.ProblemCheckRun) ProblemCheckRunRecord {
+	return ProblemCheckRunRecord{
+		ID:            run.ID,
+		ProblemID:     run.ProblemID,
+		TestcaseSetID: int8FromDB(run.TestcaseSetID),
+		RequestedBy:   int8FromDB(run.RequestedBy),
+		Status:        run.Status,
+		Summary:       jsonRawFromDB(run.Summary),
+		ErrorMessage:  textFromDB(run.ErrorMessage),
+		StartedAt:     timeFromDB(run.StartedAt),
+		FinishedAt:    timeFromDB(run.FinishedAt),
+		CreatedAt:     timeFromDB(run.CreatedAt),
+		UpdatedAt:     timeFromDB(run.UpdatedAt),
+	}
+}
+
+func problemCheckFindingFromDB(finding db.ProblemCheckFinding) ProblemCheckFindingRecord {
+	return ProblemCheckFindingRecord{
+		ID:          finding.ID,
+		RunID:       finding.RunID,
+		Severity:    finding.Severity,
+		Code:        finding.Code,
+		Message:     finding.Message,
+		CaseIndex:   int4FromDB(finding.CaseIndex),
+		TestcaseKey: textFromDB(finding.TestcaseKey),
+		Details:     jsonRawFromDB(finding.Details),
+		CreatedAt:   timeFromDB(finding.CreatedAt),
+	}
+}
+
+func problemCheckRunFromRecord(record ProblemCheckRunRecord) ProblemCheckRun {
+	summary := ProblemCheckSummary{}
+	if len(record.Summary) > 0 {
+		_ = json.Unmarshal(record.Summary, &summary)
+	}
+	return ProblemCheckRun{
+		ID:            record.ID,
+		ProblemID:     record.ProblemID,
+		TestcaseSetID: record.TestcaseSetID,
+		RequestedBy:   record.RequestedBy,
+		Status:        record.Status,
+		Summary:       summary,
+		ErrorMessage:  record.ErrorMessage,
+		StartedAt:     record.StartedAt,
+		FinishedAt:    record.FinishedAt,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+	}
+}
+
+func problemCheckFindingFromRecord(record ProblemCheckFindingRecord) ProblemCheckFinding {
+	return ProblemCheckFinding{
+		ID:          record.ID,
+		RunID:       record.RunID,
+		Severity:    record.Severity,
+		Code:        record.Code,
+		Message:     record.Message,
+		CaseIndex:   record.CaseIndex,
+		TestcaseKey: record.TestcaseKey,
+		Details:     jsonRawFromDB(record.Details),
+		CreatedAt:   record.CreatedAt,
+	}
+}
+
 func statsFromDB(row db.GetProblemStatsRow) ProblemStats {
 	stats := ProblemStats{
 		ProblemID:           row.ProblemID,
@@ -558,6 +837,69 @@ func int4Ptr(value *int32) pgtype.Int4 {
 		return pgtype.Int4{}
 	}
 	return pgtype.Int4{Int32: *value, Valid: true}
+}
+
+func int4Value(value int32) pgtype.Int4 {
+	if value <= 0 {
+		return pgtype.Int4{}
+	}
+	return pgtype.Int4{Int32: value, Valid: true}
+}
+
+func int4FromDB(value pgtype.Int4) int32 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int32
+}
+
+func int8Value(value int64) pgtype.Int8 {
+	if value <= 0 {
+		return pgtype.Int8{}
+	}
+	return pgtype.Int8{Int64: value, Valid: true}
+}
+
+func int8FromDB(value pgtype.Int8) int64 {
+	if !value.Valid {
+		return 0
+	}
+	return value.Int64
+}
+
+func timeArg(value time.Time) pgtype.Timestamptz {
+	if value.IsZero() {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: value.UTC(), Valid: true}
+}
+
+func timeFromDB(value pgtype.Timestamptz) time.Time {
+	if !value.Valid {
+		return time.Time{}
+	}
+	return value.Time
+}
+
+func textFromDB(value pgtype.Text) string {
+	if !value.Valid {
+		return ""
+	}
+	return value.String
+}
+
+func jsonbArg(value json.RawMessage) []byte {
+	if len(value) == 0 {
+		return []byte("{}")
+	}
+	return append([]byte(nil), value...)
+}
+
+func jsonRawFromDB(value []byte) json.RawMessage {
+	if len(value) == 0 {
+		return json.RawMessage("{}")
+	}
+	return append(json.RawMessage(nil), value...)
 }
 
 func stringsTrim(value string) string {

--- a/internal/problem/routes.go
+++ b/internal/problem/routes.go
@@ -20,5 +20,7 @@ func (m *Module) RegisterRoutes(group *gin.RouterGroup) {
 	problems.POST("/:id/statement", m.handler.createStatement)
 	problems.GET("/:id/statement", m.handler.currentStatement)
 	problems.POST("/:id/testcase-sets", m.handler.uploadTestcases)
+	problems.POST("/:id/checks", m.handler.runProblemCheck)
+	problems.GET("/:id/checks/:check_id", m.handler.getProblemCheck)
 	problems.GET("/:id/stats", m.handler.stats)
 }

--- a/internal/problem/service.go
+++ b/internal/problem/service.go
@@ -1,6 +1,7 @@
 package problem
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	crand "crypto/rand"
@@ -9,7 +10,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"path"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,6 +37,16 @@ const (
 	StatusArchived  = "archived"
 
 	TestcaseStatusReady = "ready"
+
+	ProblemCheckStatusQueued    = "queued"
+	ProblemCheckStatusRunning   = "running"
+	ProblemCheckStatusCompleted = "completed"
+	ProblemCheckStatusFailed    = "failed"
+	ProblemCheckStatusCanceled  = "canceled"
+
+	ProblemCheckSeverityInfo    = "info"
+	ProblemCheckSeverityWarning = "warning"
+	ProblemCheckSeverityError   = "error"
 )
 
 type ProblemRecord struct {
@@ -193,6 +208,50 @@ type UploadTestcaseInput struct {
 	CaseCount      int32  `json:"case_count"`
 	ChecksumSHA256 string `json:"checksum_sha256"`
 	ContentType    string `json:"content_type"`
+}
+
+type ProblemCheckSummary struct {
+	FindingCount      int   `json:"finding_count"`
+	ErrorCount        int   `json:"error_count"`
+	WarningCount      int   `json:"warning_count"`
+	InfoCount         int   `json:"info_count"`
+	ExpectedCaseCount int32 `json:"expected_case_count"`
+	CaseCount         int   `json:"case_count"`
+	StorageReadable   bool  `json:"storage_readable"`
+	ZipReadable       bool  `json:"zip_readable"`
+	Valid             bool  `json:"valid"`
+}
+
+type ProblemCheckRun struct {
+	ID            int64                 `json:"id"`
+	ProblemID     int64                 `json:"problem_id"`
+	TestcaseSetID int64                 `json:"testcase_set_id,omitempty"`
+	RequestedBy   int64                 `json:"requested_by,omitempty"`
+	Status        string                `json:"status"`
+	Summary       ProblemCheckSummary   `json:"summary"`
+	ErrorMessage  string                `json:"error_message,omitempty"`
+	Findings      []ProblemCheckFinding `json:"findings"`
+	StartedAt     time.Time             `json:"started_at,omitempty"`
+	FinishedAt    time.Time             `json:"finished_at,omitempty"`
+	CreatedAt     time.Time             `json:"created_at,omitempty"`
+	UpdatedAt     time.Time             `json:"updated_at,omitempty"`
+}
+
+type ProblemCheckFinding struct {
+	ID          int64           `json:"id"`
+	RunID       int64           `json:"run_id"`
+	Severity    string          `json:"severity"`
+	Code        string          `json:"code"`
+	Message     string          `json:"message"`
+	CaseIndex   int32           `json:"case_index,omitempty"`
+	TestcaseKey string          `json:"testcase_key,omitempty"`
+	Details     json.RawMessage `json:"details"`
+	CreatedAt   time.Time       `json:"created_at,omitempty"`
+}
+
+type ProblemCheckResult struct {
+	Run      ProblemCheckRun       `json:"run"`
+	Findings []ProblemCheckFinding `json:"findings"`
 }
 
 type Service struct {
@@ -451,6 +510,143 @@ func (s *Service) UploadTestcaseArchive(ctx context.Context, actor auth.Actor, p
 	return created, err
 }
 
+func (s *Service) RunProblemCheck(ctx context.Context, actor auth.Actor, problemID int64) (ProblemCheckResult, error) {
+	p, err := s.repo.GetProblem(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	statement, err := s.repo.GetCurrentProblemStatement(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	set, err := s.repo.GetCurrentReadyTestcaseSet(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	findings := validateProblemCheckStatementSamples(statement)
+	storageReadable := false
+	zipReadable := false
+	caseCount := 0
+	if s.storage == nil {
+		findings = append(findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.storage_unreadable",
+			message:  "testcase object storage is unavailable",
+			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+		})
+	} else if strings.TrimSpace(set.StorageKey) == "" {
+		findings = append(findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.storage_unreadable",
+			message:  "testcase archive storage key is missing",
+		})
+	} else {
+		body, _, err := s.storage.Get(ctx, set.StorageKey)
+		if err != nil {
+			findings = append(findings, problemCheckFindingDraft{
+				severity: ProblemCheckSeverityError,
+				code:     "testcase.storage_unreadable",
+				message:  "testcase archive cannot be read from storage",
+				details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+			})
+		} else {
+			storageReadable = true
+			data, err := readAllAndClose(body)
+			if err != nil {
+				storageReadable = false
+				findings = append(findings, problemCheckFindingDraft{
+					severity: ProblemCheckSeverityError,
+					code:     "testcase.storage_unreadable",
+					message:  "testcase archive cannot be read from storage",
+					details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+				})
+			} else {
+				archiveResult := validateProblemCheckArchive(data, set)
+				zipReadable = archiveResult.zipReadable
+				caseCount = archiveResult.caseCount
+				findings = append(findings, archiveResult.findings...)
+			}
+		}
+	}
+
+	summary := problemCheckSummary(set.CaseCount, caseCount, storageReadable, zipReadable, findings)
+	summaryJSON, err := marshalProblemCheckSummary(summary)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	var runRecord ProblemCheckRunRecord
+	persistedFindings := make([]ProblemCheckFinding, 0, len(findings))
+	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
+		run, err := repo.CreateProblemCheckRun(ctx, CreateProblemCheckRunInput{
+			ProblemID:     problemID,
+			TestcaseSetID: set.ID,
+			RequestedBy:   actor.UserID,
+			Status:        ProblemCheckStatusRunning,
+			Summary:       json.RawMessage(`{}`),
+		})
+		if err != nil {
+			return err
+		}
+		for _, finding := range findings {
+			record, err := repo.CreateProblemCheckFinding(ctx, CreateProblemCheckFindingInput{
+				RunID:       run.ID,
+				Severity:    finding.severity,
+				Code:        finding.code,
+				Message:     finding.message,
+				CaseIndex:   finding.caseIndex,
+				TestcaseKey: finding.testcaseKey,
+				Details:     finding.details,
+			})
+			if err != nil {
+				return err
+			}
+			persistedFindings = append(persistedFindings, serviceProblemCheckFindingFromRecord(record))
+		}
+		runRecord, err = repo.CompleteProblemCheckRun(ctx, CompleteProblemCheckRunInput{
+			ID:         run.ID,
+			Summary:    summaryJSON,
+			FinishedAt: s.now(),
+		})
+		return err
+	})
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	return ProblemCheckResult{Run: serviceProblemCheckRunFromRecord(runRecord), Findings: persistedFindings}, nil
+}
+
+func (s *Service) GetProblemCheck(ctx context.Context, actor auth.Actor, problemID int64, checkID int64) (ProblemCheckResult, error) {
+	p, err := s.repo.GetProblem(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemCheckResult{}, err
+	}
+	run, err := s.repo.GetProblemCheckRun(ctx, checkID)
+	if err != nil {
+		return ProblemCheckResult{}, problemCheckNotFoundErr(err)
+	}
+	if run.ProblemID != problemID {
+		return ProblemCheckResult{}, apperror.NotFound("problem_check.not_found", "problem check not found")
+	}
+	records, err := s.repo.ListProblemCheckFindings(ctx, checkID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	findings := make([]ProblemCheckFinding, 0, len(records))
+	for _, record := range records {
+		findings = append(findings, serviceProblemCheckFindingFromRecord(record))
+	}
+	return ProblemCheckResult{Run: serviceProblemCheckRunFromRecord(run), Findings: findings}, nil
+}
+
 func (s *Service) ProblemResponse(ctx context.Context, p ProblemRecord) (ProblemResponse, error) {
 	tags, err := s.repo.ListProblemTags(ctx, p.ID)
 	if err != nil {
@@ -564,6 +760,259 @@ func ensurePublishable(ctx context.Context, repo Repository, problemID int64) er
 		return apperror.Unprocessable("problem.not_publishable", "current ready testcase set is required before publishing")
 	}
 	return nil
+}
+
+type problemCheckFindingDraft struct {
+	severity    string
+	code        string
+	message     string
+	caseIndex   int32
+	testcaseKey string
+	details     json.RawMessage
+}
+
+type problemCheckArchiveValidationResult struct {
+	findings    []problemCheckFindingDraft
+	caseCount   int
+	zipReadable bool
+}
+
+func validateProblemCheckArchive(data []byte, set TestcaseSetRecord) problemCheckArchiveValidationResult {
+	result := problemCheckArchiveValidationResult{}
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.zip_invalid",
+			message:  "testcase archive must be a valid zip file",
+			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+		})
+		return result
+	}
+	result.zipReadable = true
+
+	inputs := map[string]string{}
+	outputs := map[string]string{}
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		name := path.Base(file.Name)
+		lower := strings.ToLower(name)
+		matches := caseNameRE.FindStringSubmatch(lower)
+		if len(matches) != 2 {
+			continue
+		}
+		if strings.HasPrefix(lower, "input") {
+			inputs[matches[1]] = name
+		} else {
+			outputs[matches[1]] = name
+		}
+	}
+
+	if len(inputs) == 0 && len(outputs) == 0 {
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.archive_empty",
+			message:  "testcase archive has no input/output pairs",
+			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+		})
+	}
+
+	ids := sortedProblemCheckCaseIDs(inputs)
+	for _, id := range ids {
+		if _, ok := outputs[id]; ok {
+			result.caseCount++
+			continue
+		}
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity:    ProblemCheckSeverityError,
+			code:        "testcase.output_missing",
+			message:     "each input must have a matching output",
+			caseIndex:   problemCheckCaseIndex(id),
+			testcaseKey: inputs[id],
+			details:     problemCheckDetails(map[string]any{"case_id": id, "input": inputs[id]}),
+		})
+	}
+
+	ids = sortedProblemCheckCaseIDs(outputs)
+	for _, id := range ids {
+		if _, ok := inputs[id]; ok {
+			continue
+		}
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity:    ProblemCheckSeverityError,
+			code:        "testcase.input_missing",
+			message:     "each output must have a matching input",
+			caseIndex:   problemCheckCaseIndex(id),
+			testcaseKey: outputs[id],
+			details:     problemCheckDetails(map[string]any{"case_id": id, "output": outputs[id]}),
+		})
+	}
+
+	if int32(result.caseCount) != set.CaseCount {
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.case_count_mismatch",
+			message:  "case_count does not match input/output pairs",
+			details: problemCheckDetails(map[string]any{
+				"expected_case_count": set.CaseCount,
+				"actual_case_count":   result.caseCount,
+			}),
+		})
+	}
+	return result
+}
+
+func validateProblemCheckStatementSamples(statement Statement) []problemCheckFindingDraft {
+	samplesJSON := strings.TrimSpace(string(statement.Samples))
+	if samplesJSON == "" {
+		return nil
+	}
+	if !strings.HasPrefix(samplesJSON, "[") {
+		return []problemCheckFindingDraft{statementSamplesInvalidFinding(0)}
+	}
+
+	var samples []map[string]json.RawMessage
+	if err := json.Unmarshal(statement.Samples, &samples); err != nil {
+		return []problemCheckFindingDraft{statementSamplesInvalidFinding(0)}
+	}
+	for index, sample := range samples {
+		if !problemCheckSampleStringField(sample, "input") || !problemCheckSampleStringField(sample, "output") {
+			return []problemCheckFindingDraft{statementSamplesInvalidFinding(index + 1)}
+		}
+	}
+	return nil
+}
+
+func statementSamplesInvalidFinding(sampleIndex int) problemCheckFindingDraft {
+	details := map[string]any{}
+	if sampleIndex > 0 {
+		details["sample_index"] = sampleIndex
+	}
+	return problemCheckFindingDraft{
+		severity: ProblemCheckSeverityError,
+		code:     "statement.samples_invalid",
+		message:  "statement samples must be a JSON array with string input and output fields",
+		details:  problemCheckDetails(details),
+	}
+}
+
+func problemCheckSampleStringField(sample map[string]json.RawMessage, key string) bool {
+	raw, ok := sample[key]
+	if !ok {
+		return false
+	}
+	var value string
+	return json.Unmarshal(raw, &value) == nil
+}
+
+func sortedProblemCheckCaseIDs(files map[string]string) []string {
+	ids := make([]string, 0, len(files))
+	for id := range files {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if len(ids[i]) != len(ids[j]) {
+			return len(ids[i]) < len(ids[j])
+		}
+		return ids[i] < ids[j]
+	})
+	return ids
+}
+
+func problemCheckCaseIndex(id string) int32 {
+	value, err := strconv.ParseInt(id, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int32(value)
+}
+
+func problemCheckSummary(expectedCaseCount int32, caseCount int, storageReadable, zipReadable bool, findings []problemCheckFindingDraft) ProblemCheckSummary {
+	summary := ProblemCheckSummary{
+		FindingCount:      len(findings),
+		ExpectedCaseCount: expectedCaseCount,
+		CaseCount:         caseCount,
+		StorageReadable:   storageReadable,
+		ZipReadable:       zipReadable,
+	}
+	for _, finding := range findings {
+		switch finding.severity {
+		case ProblemCheckSeverityError:
+			summary.ErrorCount++
+		case ProblemCheckSeverityWarning:
+			summary.WarningCount++
+		case ProblemCheckSeverityInfo:
+			summary.InfoCount++
+		}
+	}
+	summary.Valid = summary.ErrorCount == 0
+	return summary
+}
+
+func marshalProblemCheckSummary(summary ProblemCheckSummary) (json.RawMessage, error) {
+	data, err := json.Marshal(summary)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
+}
+
+func problemCheckDetails(value map[string]any) json.RawMessage {
+	if len(value) == 0 {
+		return json.RawMessage(`{}`)
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return json.RawMessage(data)
+}
+
+func serviceProblemCheckRunFromRecord(record ProblemCheckRunRecord) ProblemCheckRun {
+	summary := ProblemCheckSummary{}
+	if len(record.Summary) > 0 {
+		_ = json.Unmarshal(record.Summary, &summary)
+	}
+	return ProblemCheckRun{
+		ID:            record.ID,
+		ProblemID:     record.ProblemID,
+		TestcaseSetID: record.TestcaseSetID,
+		RequestedBy:   record.RequestedBy,
+		Status:        record.Status,
+		Summary:       summary,
+		ErrorMessage:  record.ErrorMessage,
+		StartedAt:     record.StartedAt,
+		FinishedAt:    record.FinishedAt,
+		CreatedAt:     record.CreatedAt,
+		UpdatedAt:     record.UpdatedAt,
+	}
+}
+
+func serviceProblemCheckFindingFromRecord(record ProblemCheckFindingRecord) ProblemCheckFinding {
+	details := record.Details
+	if len(details) == 0 {
+		details = json.RawMessage(`{}`)
+	}
+	return ProblemCheckFinding{
+		ID:          record.ID,
+		RunID:       record.RunID,
+		Severity:    record.Severity,
+		Code:        record.Code,
+		Message:     record.Message,
+		CaseIndex:   record.CaseIndex,
+		TestcaseKey: record.TestcaseKey,
+		Details:     details,
+		CreatedAt:   record.CreatedAt,
+	}
+}
+
+func problemCheckNotFoundErr(err error) error {
+	if appErr, ok := apperror.From(err); ok && appErr.HTTPStatus == http.StatusNotFound {
+		return apperror.NotFound("problem_check.not_found", "problem check not found")
+	}
+	return err
 }
 
 func requireAuthenticated(actor auth.Actor) error {

--- a/internal/problem/service_test.go
+++ b/internal/problem/service_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"sort"
@@ -219,6 +220,200 @@ func TestConcurrentUploadSerializesVersionAllocation(t *testing.T) {
 	}
 }
 
+func TestRunProblemCheckRequiresOwnerOrAdmin(t *testing.T) {
+	repo := newFakeRepository()
+	store := &fakeStorage{}
+	seedProblemCheckData(t, repo, store, `[]`, zipArchive(t, map[string]string{
+		"input1.txt":  "1\n",
+		"output1.txt": "1\n",
+	}), 1)
+	service := NewService(repo, store)
+
+	_, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1)
+	assertAppCode(t, err, "problem.forbidden")
+
+	if _, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1); err != nil {
+		t.Fatalf("owner check failed: %v", err)
+	}
+	if _, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 99, Role: auth.RoleAdmin}, 1); err != nil {
+		t.Fatalf("admin check failed: %v", err)
+	}
+}
+
+func TestRunProblemCheckPersistsCompletedRunAndSummary(t *testing.T) {
+	repo := newFakeRepository()
+	store := &fakeStorage{}
+	seedProblemCheckData(t, repo, store, `[{"input":"1 1\n","output":"2\n"}]`, zipArchive(t, map[string]string{
+		"input1.txt":  "1 1\n",
+		"output1.txt": "2\n",
+		"input2.txt":  "2 3\n",
+		"output2.txt": "5\n",
+	}), 2)
+	service := NewService(repo, store)
+	service.now = func() time.Time { return time.Unix(100, 0).UTC() }
+
+	result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
+	if err != nil {
+		t.Fatalf("RunProblemCheck returned error: %v", err)
+	}
+
+	if result.Run.ID == 0 || result.Run.Status != ProblemCheckStatusCompleted {
+		t.Fatalf("run = %+v", result.Run)
+	}
+	if result.Run.ProblemID != 1 || result.Run.TestcaseSetID != 7 || result.Run.RequestedBy != 10 {
+		t.Fatalf("run linkage = %+v", result.Run)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings, got %+v", result.Findings)
+	}
+	if result.Run.Summary.CaseCount != 2 || result.Run.Summary.ExpectedCaseCount != 2 {
+		t.Fatalf("summary case counts = %+v", result.Run.Summary)
+	}
+	if !result.Run.Summary.StorageReadable || !result.Run.Summary.ZipReadable {
+		t.Fatalf("summary readability = %+v", result.Run.Summary)
+	}
+	if len(repo.checkRuns) != 1 || repo.checkRuns[result.Run.ID].Status != ProblemCheckStatusCompleted {
+		t.Fatalf("persisted runs = %+v", repo.checkRuns)
+	}
+}
+
+func TestRunProblemCheckReportsArchiveFindings(t *testing.T) {
+	tests := []struct {
+		name      string
+		archive   []byte
+		caseCount int32
+		wantCodes []string
+	}{
+		{
+			name:      "unreadable storage object",
+			archive:   nil,
+			caseCount: 1,
+			wantCodes: []string{"testcase.storage_unreadable"},
+		},
+		{
+			name:      "invalid zip",
+			archive:   []byte("not a zip"),
+			caseCount: 1,
+			wantCodes: []string{"testcase.zip_invalid"},
+		},
+		{
+			name:      "empty archive",
+			archive:   zipArchive(t, nil),
+			caseCount: 1,
+			wantCodes: []string{"testcase.archive_empty", "testcase.case_count_mismatch"},
+		},
+		{
+			name: "missing pairs and case count mismatch",
+			archive: zipArchive(t, map[string]string{
+				"input1.txt":  "1\n",
+				"output2.txt": "2\n",
+			}),
+			caseCount: 2,
+			wantCodes: []string{"testcase.output_missing", "testcase.input_missing", "testcase.case_count_mismatch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newFakeRepository()
+			store := &fakeStorage{}
+			seedProblemCheckData(t, repo, store, `[]`, tt.archive, tt.caseCount)
+			service := NewService(repo, store)
+
+			result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
+			if err != nil {
+				t.Fatalf("RunProblemCheck returned error: %v", err)
+			}
+
+			if result.Run.Status != ProblemCheckStatusCompleted {
+				t.Fatalf("run status = %s, want completed", result.Run.Status)
+			}
+			assertFindingCodes(t, result.Findings, tt.wantCodes)
+			if result.Run.Summary.ErrorCount != len(tt.wantCodes) {
+				t.Fatalf("summary = %+v, want %d errors", result.Run.Summary, len(tt.wantCodes))
+			}
+			if len(repo.checkFindings[result.Run.ID]) != len(tt.wantCodes) {
+				t.Fatalf("persisted findings = %+v", repo.checkFindings)
+			}
+		})
+	}
+}
+
+func TestRunProblemCheckReportsStatementSampleJSONFindings(t *testing.T) {
+	tests := []struct {
+		name    string
+		samples string
+		code    string
+	}{
+		{name: "invalid json", samples: `{`, code: "statement.samples_invalid"},
+		{name: "null", samples: `null`, code: "statement.samples_invalid"},
+		{name: "not an array", samples: `{"input":"1\n","output":"1\n"}`, code: "statement.samples_invalid"},
+		{name: "missing output", samples: `[{"input":"1\n"}]`, code: "statement.samples_invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newFakeRepository()
+			store := &fakeStorage{}
+			seedProblemCheckData(t, repo, store, tt.samples, zipArchive(t, map[string]string{
+				"input1.txt":  "1\n",
+				"output1.txt": "1\n",
+			}), 1)
+			service := NewService(repo, store)
+
+			result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
+			if err != nil {
+				t.Fatalf("RunProblemCheck returned error: %v", err)
+			}
+
+			assertFindingCodes(t, result.Findings, []string{tt.code})
+		})
+	}
+}
+
+func TestGetProblemCheckReturnsCheckNotFoundForMissingRun(t *testing.T) {
+	repo := newFakeRepository()
+	store := &fakeStorage{}
+	seedProblemCheckData(t, repo, store, `[]`, zipArchive(t, map[string]string{
+		"input1.txt":  "1\n",
+		"output1.txt": "1\n",
+	}), 1)
+	service := NewService(repo, store)
+
+	_, err := service.GetProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, 99)
+
+	assertAppCode(t, err, "problem_check.not_found")
+}
+
+func seedProblemCheckData(t *testing.T, repo *fakeRepository, store *fakeStorage, samples string, archive []byte, caseCount int32) {
+	t.Helper()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate, CurrentStatementID: 3, CurrentTestcaseSetID: 7, CurrentTestcaseStatus: TestcaseStatusReady}
+	repo.statements[3] = Statement{ID: 3, ProblemID: 1, Version: 1, Title: "A", Description: "desc", Samples: json.RawMessage(samples), IsCurrent: true}
+	repo.currentStatement[1] = 3
+	repo.testcaseSets[7] = TestcaseSetRecord{ID: 7, ProblemID: 1, Version: 1, StorageKey: "cases.zip", CaseCount: caseCount, Status: TestcaseStatusReady, IsCurrent: true}
+	repo.currentTestcase[1] = 7
+	if archive != nil {
+		store.objects = map[string][]byte{"cases.zip": archive}
+	}
+}
+
+func assertFindingCodes(t *testing.T, findings []ProblemCheckFinding, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		got = append(got, finding.Code)
+		if finding.Severity != ProblemCheckSeverityError {
+			t.Fatalf("finding %s severity = %s, want error", finding.Code, finding.Severity)
+		}
+	}
+	sort.Strings(got)
+	want = append([]string(nil), want...)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("finding codes = %v, want %v; findings=%+v", got, want, findings)
+	}
+}
+
 type fakeRepository struct {
 	mu                    sync.Mutex
 	problems              map[int64]ProblemRecord
@@ -226,11 +421,15 @@ type fakeRepository struct {
 	currentStatement      map[int64]int64
 	testcaseSets          map[int64]TestcaseSetRecord
 	currentTestcase       map[int64]int64
+	checkRuns             map[int64]ProblemCheckRunRecord
+	checkFindings         map[int64][]ProblemCheckFindingRecord
 	tags                  map[int64][]Tag
 	nextProblemID         int64
 	nextTagID             int64
 	nextStatementID       int64
 	nextTestcaseID        int64
+	nextCheckRunID        int64
+	nextCheckFindingID    int64
 	nextArtifactID        int64
 	failCreateTestcaseSet bool
 }
@@ -242,6 +441,8 @@ func newFakeRepository() *fakeRepository {
 		currentStatement: map[int64]int64{},
 		testcaseSets:     map[int64]TestcaseSetRecord{},
 		currentTestcase:  map[int64]int64{},
+		checkRuns:        map[int64]ProblemCheckRunRecord{},
+		checkFindings:    map[int64][]ProblemCheckFindingRecord{},
 		tags:             map[int64][]Tag{},
 	}
 }
@@ -416,6 +617,136 @@ func (r *fakeRepository) GetCurrentReadyTestcaseSet(ctx context.Context, problem
 		return TestcaseSetRecord{}, apperror.NotFound("problem.not_found", "problem not found")
 	}
 	return set, nil
+}
+
+func (r *fakeRepository) CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	r.nextCheckRunID++
+	now := time.Now()
+	status := input.Status
+	if status == "" {
+		status = ProblemCheckStatusQueued
+	}
+	run := ProblemCheckRunRecord{
+		ID:            r.nextCheckRunID,
+		ProblemID:     input.ProblemID,
+		TestcaseSetID: input.TestcaseSetID,
+		RequestedBy:   input.RequestedBy,
+		Status:        status,
+		Summary:       jsonRawFromDB(input.Summary),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	r.checkRuns[run.ID] = run
+	return run, nil
+}
+
+func (r *fakeRepository) GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error) {
+	run, ok := r.checkRuns[id]
+	if !ok {
+		return ProblemCheckRunRecord{}, apperror.NotFound("problem.not_found", "problem not found")
+	}
+	return run, nil
+}
+
+func (r *fakeRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
+	runs := make([]ProblemCheckRunRecord, 0)
+	for _, run := range r.checkRuns {
+		if run.ProblemID == filter.ProblemID {
+			runs = append(runs, run)
+		}
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i].CreatedAt.Equal(runs[j].CreatedAt) {
+			return runs[i].ID > runs[j].ID
+		}
+		return runs[i].CreatedAt.After(runs[j].CreatedAt)
+	})
+	if filter.Offset >= int32(len(runs)) {
+		return nil, nil
+	}
+	start := int(filter.Offset)
+	end := start + int(filter.Limit)
+	if filter.Limit <= 0 {
+		end = start
+	}
+	if end > len(runs) {
+		end = len(runs)
+	}
+	return append([]ProblemCheckRunRecord(nil), runs[start:end]...), nil
+}
+
+func (r *fakeRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	run, ok := r.checkRuns[input.ID]
+	if !ok || (run.Status != ProblemCheckStatusQueued && run.Status != ProblemCheckStatusRunning) {
+		return ProblemCheckRunRecord{}, apperror.NotFound("problem.not_found", "problem not found")
+	}
+	now := time.Now()
+	finishedAt := input.FinishedAt
+	if finishedAt.IsZero() {
+		finishedAt = now
+	}
+	run.Status = ProblemCheckStatusCompleted
+	run.Summary = jsonRawFromDB(input.Summary)
+	run.ErrorMessage = ""
+	run.FinishedAt = finishedAt
+	run.UpdatedAt = now
+	r.checkRuns[run.ID] = run
+	return run, nil
+}
+
+func (r *fakeRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	run, ok := r.checkRuns[input.ID]
+	if !ok || (run.Status != ProblemCheckStatusQueued && run.Status != ProblemCheckStatusRunning) {
+		return ProblemCheckRunRecord{}, apperror.NotFound("problem.not_found", "problem not found")
+	}
+	now := time.Now()
+	finishedAt := input.FinishedAt
+	if finishedAt.IsZero() {
+		finishedAt = now
+	}
+	run.Status = ProblemCheckStatusFailed
+	run.Summary = jsonRawFromDB(input.Summary)
+	run.ErrorMessage = input.ErrorMessage
+	run.FinishedAt = finishedAt
+	run.UpdatedAt = now
+	r.checkRuns[run.ID] = run
+	return run, nil
+}
+
+func (r *fakeRepository) CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
+	r.nextCheckFindingID++
+	finding := ProblemCheckFindingRecord{
+		ID:          r.nextCheckFindingID,
+		RunID:       input.RunID,
+		Severity:    input.Severity,
+		Code:        input.Code,
+		Message:     input.Message,
+		CaseIndex:   input.CaseIndex,
+		TestcaseKey: input.TestcaseKey,
+		Details:     jsonRawFromDB(input.Details),
+		CreatedAt:   time.Now(),
+	}
+	r.checkFindings[finding.RunID] = append(r.checkFindings[finding.RunID], finding)
+	return finding, nil
+}
+
+func (r *fakeRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
+	for _, findings := range r.checkFindings {
+		for _, finding := range findings {
+			if finding.ID == id {
+				return finding, nil
+			}
+		}
+	}
+	return ProblemCheckFindingRecord{}, apperror.NotFound("problem.not_found", "problem not found")
+}
+
+func (r *fakeRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {
+	findings := append([]ProblemCheckFindingRecord(nil), r.checkFindings[runID]...)
+	sort.Slice(findings, func(i, j int) bool {
+		return findings[i].ID < findings[j].ID
+	})
+	return findings, nil
 }
 
 func (r *fakeRepository) CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error) {

--- a/internal/submission/async_test.go
+++ b/internal/submission/async_test.go
@@ -243,10 +243,10 @@ func main() { var a, b int; fmt.Scan(&a, &b); fmt.Println(a + b) }
 			Index:             1,
 			InputKey:          "1 2\n",
 			ExpectedOutputKey: "3\n",
-			TimeLimitMS:       1000,
+			TimeLimitMS:       5000,
 			MemoryKB:          262144,
 		}},
-		TimeoutMS: 1000,
+		TimeoutMS: 5000,
 		MemoryKB:  262144,
 		CreatedAt: time.Unix(100, 0).UTC(),
 	}


### PR DESCRIPTION
## Summary

Adds a synchronous problem data validation MVP so owners/admins can validate the current ready testcase archive and fetch persisted check results through the v2 API.

## Changes

- Adds `POST /api/v1/problems/{id}/checks` and `GET /api/v1/problems/{id}/checks/{check_id}` with standard response envelopes.
- Reuses the existing `problem_check_runs` and `problem_check_findings` persistence surface; no migration is required for this slice.
- Validates archive readability, zip parseability, input/output pairing, case count mismatches, empty archives, and statement sample JSON shape.
- Updates OpenAPI and the v2 API guide with check run, finding, summary, status, severity, and error contract details.
- Widens accepted-path judge test timeouts so CI's default package parallelism does not misclassify valid Go programs as timeouts; dedicated timeout tests still cover timeout behavior.
- Makes the Docker smoke metric check pipe-safe under `set -o pipefail` by avoiding `curl | grep -q` SIGPIPE false negatives.

## Validation

- `go test -count=1 ./internal/problem`
- `go test -count=1 ./internal/postgres/db`
- `go test -count=1 ./internal/judgecore`
- `go test -count=1 ./internal/submission`
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- `bash -n deploy/smoke.sh`
- Local pipe-safe metric grep reproduction
- OpenAPI YAML parse and problem-check path/schema assertions

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)