### PR TITLE
feat(problem): enforce authoring publish readiness

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -162,6 +162,10 @@ paths:
           in: query
           description: Admin/root only.
           schema: { $ref: "#/components/schemas/ProblemStatus" }
+        - name: mine
+          in: query
+          description: When true, requires authentication and returns only problems owned by the current user.
+          schema: { type: boolean, default: false }
       responses:
         "200":
           description: Problem page.
@@ -302,6 +306,26 @@ paths:
         "403": { $ref: "#/components/responses/PermissionDenied" }
         "404": { $ref: "#/components/responses/NotFound" }
         "422": { $ref: "#/components/responses/ValidationFailed" }
+        "500": { $ref: "#/components/responses/InternalError" }
+  /api/v1/problems/{id}/authoring:
+    parameters:
+      - $ref: "#/components/parameters/ID"
+    get:
+      tags: [Problems]
+      operationId: getProblemAuthoringState
+      summary: Get the owner authoring state for a problem
+      x-owner: WP3 Problem
+      x-auth: owner-admin-root
+      responses:
+        "200":
+          description: Current authoring state and publish blockers.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemAuthoringStateEnvelope"
+        "401": { $ref: "#/components/responses/Unauthenticated" }
+        "403": { $ref: "#/components/responses/PermissionDenied" }
+        "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
   /api/v1/problems/{id}/testcase-sets:
     post:
@@ -1250,6 +1274,10 @@ components:
       properties:
         id: { type: integer, format: int64 }
         problem_id: { type: integer, format: int64 }
+        statement_id:
+          type: integer
+          format: int64
+          nullable: true
         testcase_set_id:
           type: integer
           format: int64
@@ -1270,6 +1298,33 @@ components:
         finished_at: { type: string, format: date-time, nullable: true }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+    ProblemAuthoringBlocker:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+    ProblemAuthoringState:
+      type: object
+      required: [problem, publishable, blockers]
+      properties:
+        problem: { $ref: "#/components/schemas/ProblemResponse" }
+        statement:
+          type: object
+          allOf: [{ $ref: "#/components/schemas/ProblemStatementResponse" }]
+          nullable: true
+        testcase_set:
+          type: object
+          allOf: [{ $ref: "#/components/schemas/TestcaseSetResponse" }]
+          nullable: true
+        latest_check:
+          type: object
+          allOf: [{ $ref: "#/components/schemas/ProblemCheckRun" }]
+          nullable: true
+        publishable: { type: boolean }
+        blockers:
+          type: array
+          items: { $ref: "#/components/schemas/ProblemAuthoringBlocker" }
     SubmissionCreateRequest:
       type: object
       required: [problem_id, language_id, source_code]
@@ -1496,7 +1551,6 @@ components:
         alias: { type: string }
         status: { $ref: "#/components/schemas/ScoreboardCellStatus" }
         attempts: { type: integer }
-        frozen_attempts: { type: integer }
         penalty_minutes: { type: integer }
         accepted_at: { type: string, format: date-time, nullable: true }
         last_submission_id: { type: integer, format: int64, nullable: true }
@@ -1593,6 +1647,9 @@ components:
     ProblemCheckRunEnvelope:
       allOf: [{ $ref: "#/components/schemas/Envelope" }]
       properties: { data: { $ref: "#/components/schemas/ProblemCheckRun" } }
+    ProblemAuthoringStateEnvelope:
+      allOf: [{ $ref: "#/components/schemas/Envelope" }]
+      properties: { data: { $ref: "#/components/schemas/ProblemAuthoringState" } }
     ProblemStatsEnvelope:
       allOf: [{ $ref: "#/components/schemas/Envelope" }]
       properties: { data: { $ref: "#/components/schemas/ProblemStatsResponse" } }

--- a/deploy/smoke.sh
+++ b/deploy/smoke.sh
@@ -138,6 +138,13 @@ curl -fsS -X POST "$API_URL/api/v1/problems/$PROBLEM_ID/testcase-sets" \
   -F "case_count=1" \
   -F "checksum_sha256=$SHA" >/dev/null
 
+CHECK_RESPONSE="$(api_json POST "/api/v1/problems/$PROBLEM_ID/checks" '{}')"
+CHECK_VALID="$(jq -r '.data.summary.valid' <<<"$CHECK_RESPONSE")"
+if [[ "$CHECK_VALID" != "true" ]]; then
+  echo "problem check did not validate current testcase set: $CHECK_RESPONSE" >&2
+  exit 1
+fi
+
 api_json PATCH "/api/v1/problems/$PROBLEM_ID" '{"status":"published"}' >/dev/null
 
 SUBMISSION_PAYLOAD="$(jq -cn --argjson problem_id "$PROBLEM_ID" --argjson language_id "$LANG_ID" --arg source "$SOURCE_CODE" '{problem_id:$problem_id,language_id:$language_id,source_code:$source}')"

--- a/docs/superpowers/plans/2026-07-11-problem-authoring-publish-gate.md
+++ b/docs/superpowers/plans/2026-07-11-problem-authoring-publish-gate.md
@@ -1,0 +1,136 @@
+# Problem Authoring And Publish Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Let an authenticated problem owner create, edit, validate, and publish a judge-ready problem from SOJ-web while SOJ rejects publication unless the current statement and testcase set have a completed valid check.
+
+**Architecture:** SOJ exposes an owner/admin-only authoring-state endpoint that aggregates the current statement, testcase set, latest relevant check, and publish blockers. Check runs bind both content versions, and the publish path reuses the same readiness evaluation while holding the problem update lock. SOJ-web extends its API adapter and adds browser-authenticated authoring pages that follow the existing Signal Arena design system.
+
+**Tech Stack:** Go 1.25, Gin, PostgreSQL/sqlc, OpenAPI, Next.js 16, React 19, TypeScript, Vitest, Playwright.
+
+---
+
+## Chunk 0: Branch And Baseline
+
+- [x] Fetch both repositories and confirm clean `main` branches match `origin/main`.
+- [x] Create backend branch `feat/problem-authoring-publish-gate` from `origin/main` in an isolated worktree.
+- [x] Create frontend branch `feat/problem-authoring-workspace` from `origin/main` in an isolated worktree.
+- [x] Configure both repositories with commit email `sparkyi@foxmail.com`.
+- [x] Run baseline `go test ./...` and `npm run ci:fast` successfully before implementation.
+
+## Chunk 1: Backend Publish Integrity
+
+### Task 1: Define Authoring Readiness Behavior
+
+**Files:**
+- Modify: `internal/problem/service_test.go`
+- Modify: `internal/problem/service.go`
+- Modify: `internal/problem/repository.go`
+- Modify: `internal/postgres/queries/problems.sql`
+- Regenerate: `internal/postgres/db/problems.sql.go`
+- Regenerate: `internal/postgres/db/querier.go`
+- Modify: `internal/postgres/db/submissions_sql_test.go`
+
+- [x] Add failing tests proving publication fails without a check, with a stale testcase-set check, and with an invalid check.
+- [x] Add a passing test proving a completed valid check for the current testcase set permits publication.
+- [x] Add repository coverage for selecting the latest completed check by `problem_id + statement_id + testcase_set_id`.
+- [x] Cover a testcase-set switch after check completion and serialize publish/upload through the problem row lock.
+- [x] Implement a single readiness evaluator used by both authoring state and `ensurePublishable`.
+- [x] Run `go test ./internal/problem`.
+
+### Task 2: Expose Authoring State
+
+**Files:**
+- Modify: `internal/problem/service_test.go`
+- Modify: `internal/problem/service.go`
+- Modify: `internal/problem/handler_test.go`
+- Modify: `internal/problem/handler.go`
+- Modify: `internal/problem/routes.go`
+- Modify: `api/openapi.yaml`
+- Modify: `docs/v2-api-guide.md`
+
+- [x] Add failing service and handler tests for owner/admin access and nullable incomplete state.
+- [x] Treat only explicit not-found statement/testcase/check results as incomplete; propagate infrastructure errors.
+- [x] Add `GET /api/v1/problems/{id}/authoring`.
+- [x] Return problem, optional current statement, optional current testcase set, optional latest current-set check, `publishable`, and stable blocker codes.
+- [x] Document the endpoint and schemas in OpenAPI/API guide.
+- [x] Run backend focused and full checks.
+
+### Task 3: Add Owner-Only Problem Listing
+
+**Files:**
+- Modify: `internal/problem/service_test.go`
+- Modify: `internal/problem/service.go`
+- Modify: `internal/problem/handler_test.go`
+- Modify: `internal/problem/handler.go`
+- Modify: `internal/postgres/queries/problems.sql`
+- Modify: `internal/problem/repository.go`
+- Regenerate: `internal/postgres/db/problems.sql.go`
+- Modify: `api/openapi.yaml`
+- Modify: `docs/v2-api-guide.md`
+
+- [x] Add failing authorization tests proving `mine=true` requires authentication and scopes results to `actor.UserID`, including for admins.
+- [x] Add an explicit owner filter to repository list/count queries instead of relying on visibility filtering.
+- [x] Document `mine=true` and consume it from the authoring workspace.
+- [x] Run focused problem and PostgreSQL query tests.
+
+## Chunk 2: Frontend Authoring Workspace
+
+### Task 4: Extend The API Boundary
+
+**Files:**
+- Modify: `lib/api/types.ts`
+- Modify: `lib/api/backend-types.ts`
+- Modify: `lib/api/http-adapter.ts`
+- Modify: `lib/api/mock-adapter.ts`
+- Modify: `tests/unit/http-adapter.test.ts`
+- Modify: `tests/unit/mock-adapter.test.ts`
+
+- [x] Add failing adapter tests for create, update, statement save, testcase upload, check execution, and authoring-state retrieval.
+- [x] Implement typed DTO mappings and multipart upload.
+- [x] Keep mock mode deterministic for UI development.
+- [x] Run focused unit tests.
+
+### Task 5: Build Authoring Pages
+
+**Files:**
+- Create: `app/manage/problems/page.tsx`
+- Create: `app/manage/problems/[id]/page.tsx`
+- Create: `features/problems/authoring/problem-manager.tsx`
+- Create: `features/problems/authoring/problem-workbench.tsx`
+- Create: `features/problems/authoring/problem-authoring-form.tsx`
+- Create: `features/problems/authoring/problem-check-panel.tsx`
+- Modify: `components/layout/top-nav.tsx`
+- Modify: `tests/unit/feature-api.test.ts`
+- Create: `tests/e2e/problem-authoring.spec.ts`
+
+- [x] Write failing component/unit tests for authoring states and commands.
+- [x] Implement the authenticated list/create page.
+- [x] Consume the authenticated `mine=true` list so authoring never exposes edit actions for another owner's public problems.
+- [x] Implement metadata and statement editing, testcase upload, check findings, and publish controls.
+- [x] Add role-aware navigation without exposing author commands to guests.
+- [x] Add browser E2E coverage.
+
+## Chunk 3: Real Integration And Delivery
+
+### Task 6: Cross-Repository HTTP Smoke
+
+**Files:**
+- Create: `SOJ-web/playwright.http.config.ts`.
+- Create: `SOJ-web/scripts/http-authoring-e2e.mjs` if stack orchestration is needed.
+- Create: `SOJ-web/tests/http/problem-authoring-http.spec.ts`.
+- Modify: `SOJ-web/package.json`.
+- Modify: `SOJ-web/docs/development/api-integration-smoke.md`.
+
+- [x] Add a repeatable command that starts/waits for SOJ, starts SOJ-web with `NEXT_PUBLIC_SOJ_API_MODE=http`, and cleans up owned processes/data.
+- [x] Generate valid and invalid testcase zip fixtures during the test without committing binary archives.
+- [x] Use Playwright to create, populate, validate, publish, and submit a problem through the browser.
+- [x] Verify invalid data cannot publish and valid data can.
+
+### Task 7: Verification And Publication
+
+- [x] Run `go test ./...`, `go vet ./...`, Compose validation, and backend smoke.
+- [x] Run `npm run ci` in SOJ-web.
+- [x] Review Go functional changes and frontend screenshots at desktop/mobile sizes.
+- [x] Reconfirm both feature branches still have the expected merge base before push.
+- [x] Commit with `sparkyi@foxmail.com`, push both branches, create linked GitHub PRs, cross-link them, note backend-first merge/deploy order, and monitor all checks to completion.

--- a/docs/v2-api-guide.md
+++ b/docs/v2-api-guide.md
@@ -77,7 +77,10 @@ Problems:
 - `POST /api/v1/problems/{id}/testcase-sets`
 - `POST /api/v1/problems/{id}/checks`
 - `GET /api/v1/problems/{id}/checks/{check_id}`
+- `GET /api/v1/problems/{id}/authoring`
 - `GET /api/v1/problems/{id}/stats`
+
+Use `GET /api/v1/problems?mine=true` with an authenticated request to list only problems owned by the current user. This is the supported source for authoring consoles.
 
 Problem checks:
 
@@ -86,6 +89,8 @@ Problem checks:
 - Check endpoints are owner/admin/root scoped. They use the same error envelope as the rest of the API.
 - `ProblemCheckRun.summary` includes archive counts, finding counts by severity, storage/zip readability flags, and `valid`.
 - `ProblemCheckRun.findings` contains stable finding `code`, `severity`, `message`, optional `case_index` and `testcase_key`, and structured `details`.
+- `GET /api/v1/problems/{id}/authoring` returns the current statement, current ready testcase set, the latest completed check for that exact statement and testcase-set pair, and stable publish blockers.
+- Publishing with `PATCH /api/v1/problems/{id}` and `status=published` requires a completed check whose summary is valid for the current statement and testcase set. Saving a replacement statement or testcase archive invalidates the previous check for publication.
 
 Submissions and runs:
 

--- a/internal/migrations/000002_problem_check_statement.up.sql
+++ b/internal/migrations/000002_problem_check_statement.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE problem_check_runs
+    ADD COLUMN statement_id bigint REFERENCES problem_statements(id);
+
+CREATE INDEX problem_check_runs_statement_id_idx ON problem_check_runs (statement_id);
+CREATE INDEX problem_check_runs_publish_gate_idx
+    ON problem_check_runs (problem_id, statement_id, testcase_set_id, finished_at DESC, id DESC)
+    WHERE status = 'completed';

--- a/internal/postgres/db/models.go
+++ b/internal/postgres/db/models.go
@@ -203,6 +203,7 @@ type ProblemCheckRun struct {
 	FinishedAt    pgtype.Timestamptz `db:"finished_at" json:"finished_at"`
 	CreatedAt     pgtype.Timestamptz `db:"created_at" json:"created_at"`
 	UpdatedAt     pgtype.Timestamptz `db:"updated_at" json:"updated_at"`
+	StatementID   pgtype.Int8        `db:"statement_id" json:"statement_id"`
 }
 
 type ProblemStatement struct {

--- a/internal/postgres/db/problems.sql.go
+++ b/internal/postgres/db/problems.sql.go
@@ -82,7 +82,7 @@ SET status = 'completed',
     updated_at = now()
 WHERE id = $3
   AND status IN ('queued', 'running')
-RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at
+RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
 `
 
 type CompleteProblemCheckRunParams struct {
@@ -106,6 +106,7 @@ func (q *Queries) CompleteProblemCheckRun(ctx context.Context, arg CompleteProbl
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.StatementID,
 	)
 	return i, err
 }
@@ -131,10 +132,11 @@ WHERE ($1::text IS NULL OR difficulty = $1::text)
       OR title ILIKE '%' || $5::text || '%'
       OR slug ILIKE '%' || $5::text || '%'
   )
+  AND ($6::bigint = 0 OR owner_user_id = $6::bigint)
   AND (
-      $6::boolean
+      $7::boolean
       OR (status = 'published' AND visibility = 'public')
-      OR ($7::bigint > 0 AND owner_user_id = $7::bigint)
+      OR ($8::bigint > 0 AND owner_user_id = $8::bigint)
   )
 `
 
@@ -144,6 +146,7 @@ type CountProblemsParams struct {
 	Visibility   pgtype.Text `db:"visibility" json:"visibility"`
 	Tag          pgtype.Text `db:"tag" json:"tag"`
 	Keyword      pgtype.Text `db:"keyword" json:"keyword"`
+	OwnerUserID  int64       `db:"owner_user_id" json:"owner_user_id"`
 	IncludeAll   bool        `db:"include_all" json:"include_all"`
 	ViewerUserID int64       `db:"viewer_user_id" json:"viewer_user_id"`
 }
@@ -155,6 +158,7 @@ func (q *Queries) CountProblems(ctx context.Context, arg CountProblemsParams) (i
 		arg.Visibility,
 		arg.Tag,
 		arg.Keyword,
+		arg.OwnerUserID,
 		arg.IncludeAll,
 		arg.ViewerUserID,
 	)
@@ -280,6 +284,7 @@ func (q *Queries) CreateProblemCheckFinding(ctx context.Context, arg CreateProbl
 const createProblemCheckRun = `-- name: CreateProblemCheckRun :one
 INSERT INTO problem_check_runs (
     problem_id,
+    statement_id,
     testcase_set_id,
     requested_by,
     status,
@@ -289,13 +294,15 @@ INSERT INTO problem_check_runs (
     $2,
     $3,
     $4,
-    $5
+    $5,
+    $6
 )
-RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at
+RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
 `
 
 type CreateProblemCheckRunParams struct {
 	ProblemID     int64       `db:"problem_id" json:"problem_id"`
+	StatementID   pgtype.Int8 `db:"statement_id" json:"statement_id"`
 	TestcaseSetID pgtype.Int8 `db:"testcase_set_id" json:"testcase_set_id"`
 	RequestedBy   pgtype.Int8 `db:"requested_by" json:"requested_by"`
 	Status        string      `db:"status" json:"status"`
@@ -305,6 +312,7 @@ type CreateProblemCheckRunParams struct {
 func (q *Queries) CreateProblemCheckRun(ctx context.Context, arg CreateProblemCheckRunParams) (ProblemCheckRun, error) {
 	row := q.db.QueryRow(ctx, createProblemCheckRun,
 		arg.ProblemID,
+		arg.StatementID,
 		arg.TestcaseSetID,
 		arg.RequestedBy,
 		arg.Status,
@@ -323,6 +331,7 @@ func (q *Queries) CreateProblemCheckRun(ctx context.Context, arg CreateProblemCh
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.StatementID,
 	)
 	return i, err
 }
@@ -476,7 +485,7 @@ SET status = 'failed',
     updated_at = now()
 WHERE id = $4
   AND status IN ('queued', 'running')
-RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at
+RETURNING id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
 `
 
 type FailProblemCheckRunParams struct {
@@ -506,6 +515,7 @@ func (q *Queries) FailProblemCheckRun(ctx context.Context, arg FailProblemCheckR
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.StatementID,
 	)
 	return i, err
 }
@@ -560,6 +570,43 @@ func (q *Queries) GetCurrentReadyTestcaseSet(ctx context.Context, problemID int6
 		&i.IsCurrent,
 		&i.CreatedBy,
 		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getLatestCompletedProblemCheckRun = `-- name: GetLatestCompletedProblemCheckRun :one
+SELECT id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
+FROM problem_check_runs
+WHERE problem_id = $1
+  AND statement_id = $2
+  AND testcase_set_id = $3
+  AND status = 'completed'
+ORDER BY finished_at DESC NULLS LAST, id DESC
+LIMIT 1
+`
+
+type GetLatestCompletedProblemCheckRunParams struct {
+	ProblemID     int64       `db:"problem_id" json:"problem_id"`
+	StatementID   pgtype.Int8 `db:"statement_id" json:"statement_id"`
+	TestcaseSetID pgtype.Int8 `db:"testcase_set_id" json:"testcase_set_id"`
+}
+
+func (q *Queries) GetLatestCompletedProblemCheckRun(ctx context.Context, arg GetLatestCompletedProblemCheckRunParams) (ProblemCheckRun, error) {
+	row := q.db.QueryRow(ctx, getLatestCompletedProblemCheckRun, arg.ProblemID, arg.StatementID, arg.TestcaseSetID)
+	var i ProblemCheckRun
+	err := row.Scan(
+		&i.ID,
+		&i.ProblemID,
+		&i.TestcaseSetID,
+		&i.RequestedBy,
+		&i.Status,
+		&i.Summary,
+		&i.ErrorMessage,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.StatementID,
 	)
 	return i, err
 }
@@ -694,7 +741,7 @@ func (q *Queries) GetProblemCheckFindingByID(ctx context.Context, id int64) (Pro
 }
 
 const getProblemCheckRunByID = `-- name: GetProblemCheckRunByID :one
-SELECT id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at
+SELECT id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
 FROM problem_check_runs
 WHERE id = $1
 `
@@ -714,6 +761,7 @@ func (q *Queries) GetProblemCheckRunByID(ctx context.Context, id int64) (Problem
 		&i.FinishedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.StatementID,
 	)
 	return i, err
 }
@@ -808,7 +856,7 @@ func (q *Queries) ListProblemCheckFindingsByRunID(ctx context.Context, runID int
 }
 
 const listProblemCheckRunsByProblemID = `-- name: ListProblemCheckRunsByProblemID :many
-SELECT id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at
+SELECT id, problem_id, testcase_set_id, requested_by, status, summary, error_message, started_at, finished_at, created_at, updated_at, statement_id
 FROM problem_check_runs
 WHERE problem_id = $1
 ORDER BY created_at DESC, id DESC
@@ -842,6 +890,7 @@ func (q *Queries) ListProblemCheckRunsByProblemID(ctx context.Context, arg ListP
 			&i.FinishedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.StatementID,
 		); err != nil {
 			return nil, err
 		}
@@ -908,13 +957,14 @@ WHERE ($1::text IS NULL OR p.difficulty = $1::text)
       OR p.title ILIKE '%' || $5::text || '%'
       OR p.slug ILIKE '%' || $5::text || '%'
   )
+  AND ($6::bigint = 0 OR p.owner_user_id = $6::bigint)
   AND (
-      $6::boolean
+      $7::boolean
       OR (p.status = 'published' AND p.visibility = 'public')
-      OR ($7::bigint > 0 AND p.owner_user_id = $7::bigint)
+      OR ($8::bigint > 0 AND p.owner_user_id = $8::bigint)
   )
 ORDER BY p.created_at DESC, p.id DESC
-LIMIT $9 OFFSET $8
+LIMIT $10 OFFSET $9
 `
 
 type ListProblemsParams struct {
@@ -923,6 +973,7 @@ type ListProblemsParams struct {
 	Visibility   pgtype.Text `db:"visibility" json:"visibility"`
 	Tag          pgtype.Text `db:"tag" json:"tag"`
 	Keyword      pgtype.Text `db:"keyword" json:"keyword"`
+	OwnerUserID  int64       `db:"owner_user_id" json:"owner_user_id"`
 	IncludeAll   bool        `db:"include_all" json:"include_all"`
 	ViewerUserID int64       `db:"viewer_user_id" json:"viewer_user_id"`
 	Offset       int32       `db:"offset" json:"offset"`
@@ -954,6 +1005,7 @@ func (q *Queries) ListProblems(ctx context.Context, arg ListProblemsParams) ([]L
 		arg.Visibility,
 		arg.Tag,
 		arg.Keyword,
+		arg.OwnerUserID,
 		arg.IncludeAll,
 		arg.ViewerUserID,
 		arg.Offset,

--- a/internal/postgres/db/querier.go
+++ b/internal/postgres/db/querier.go
@@ -61,6 +61,7 @@ type Querier interface {
 	GetJudgeTaskByID(ctx context.Context, id int64) (JudgeTask, error)
 	GetJudgeTaskBySubmissionID(ctx context.Context, submissionID int64) (JudgeTask, error)
 	GetLanguageByID(ctx context.Context, id int64) (Language, error)
+	GetLatestCompletedProblemCheckRun(ctx context.Context, arg GetLatestCompletedProblemCheckRunParams) (ProblemCheckRun, error)
 	GetLatestContestScoreSnapshot(ctx context.Context, arg GetLatestContestScoreSnapshotParams) (ContestScoreSnapshot, error)
 	GetLatestJudgeAttemptByRunID(ctx context.Context, runID pgtype.Int8) (JudgeAttempt, error)
 	GetLatestJudgeAttemptBySubmissionID(ctx context.Context, submissionID pgtype.Int8) (JudgeAttempt, error)

--- a/internal/postgres/db/submissions_sql_test.go
+++ b/internal/postgres/db/submissions_sql_test.go
@@ -191,17 +191,32 @@ func TestProblemCheckSchemaAndQueriesExposeRunsAndFindings(t *testing.T) {
 	}
 
 	for name, query := range map[string]string{
-		"CreateProblemCheckRun":           createProblemCheckRun,
-		"GetProblemCheckRunByID":          getProblemCheckRunByID,
-		"ListProblemCheckRunsByProblemID": listProblemCheckRunsByProblemID,
-		"CompleteProblemCheckRun":         completeProblemCheckRun,
-		"FailProblemCheckRun":             failProblemCheckRun,
-		"CreateProblemCheckFinding":       createProblemCheckFinding,
-		"GetProblemCheckFindingByID":      getProblemCheckFindingByID,
-		"ListProblemCheckFindingsByRunID": listProblemCheckFindingsByRunID,
+		"CreateProblemCheckRun":             createProblemCheckRun,
+		"GetProblemCheckRunByID":            getProblemCheckRunByID,
+		"GetLatestCompletedProblemCheckRun": getLatestCompletedProblemCheckRun,
+		"ListProblemCheckRunsByProblemID":   listProblemCheckRunsByProblemID,
+		"CompleteProblemCheckRun":           completeProblemCheckRun,
+		"FailProblemCheckRun":               failProblemCheckRun,
+		"CreateProblemCheckFinding":         createProblemCheckFinding,
+		"GetProblemCheckFindingByID":        getProblemCheckFindingByID,
+		"ListProblemCheckFindingsByRunID":   listProblemCheckFindingsByRunID,
 	} {
 		if !strings.Contains(query, "problem_check_") {
 			t.Fatalf("%s does not target problem check tables:\n%s", name, query)
+		}
+	}
+	for _, want := range []string{"statement_id = $2", "testcase_set_id = $3", "status = 'completed'", "ORDER BY finished_at DESC NULLS LAST, id DESC"} {
+		if !strings.Contains(getLatestCompletedProblemCheckRun, want) {
+			t.Fatalf("GetLatestCompletedProblemCheckRun missing %q:\n%s", want, getLatestCompletedProblemCheckRun)
+		}
+	}
+	statementMigration, err := os.ReadFile(filepath.Join("..", "..", "migrations", "000002_problem_check_statement.up.sql"))
+	if err != nil {
+		t.Fatalf("read statement migration: %v", err)
+	}
+	for _, want := range []string{"ADD COLUMN statement_id", "problem_check_runs_publish_gate_idx"} {
+		if !strings.Contains(string(statementMigration), want) {
+			t.Fatalf("statement migration missing %q", want)
 		}
 	}
 	if !strings.Contains(completeProblemCheckRun, "AND status IN ('queued', 'running')") {

--- a/internal/postgres/queries/problems.sql
+++ b/internal/postgres/queries/problems.sql
@@ -64,6 +64,7 @@ WHERE (sqlc.narg('difficulty')::text IS NULL OR p.difficulty = sqlc.narg('diffic
       OR p.title ILIKE '%' || sqlc.narg('keyword')::text || '%'
       OR p.slug ILIKE '%' || sqlc.narg('keyword')::text || '%'
   )
+  AND (sqlc.arg('owner_user_id')::bigint = 0 OR p.owner_user_id = sqlc.arg('owner_user_id')::bigint)
   AND (
       sqlc.arg('include_all')::boolean
       OR (p.status = 'published' AND p.visibility = 'public')
@@ -93,6 +94,7 @@ WHERE (sqlc.narg('difficulty')::text IS NULL OR difficulty = sqlc.narg('difficul
       OR title ILIKE '%' || sqlc.narg('keyword')::text || '%'
       OR slug ILIKE '%' || sqlc.narg('keyword')::text || '%'
   )
+  AND (sqlc.arg('owner_user_id')::bigint = 0 OR owner_user_id = sqlc.arg('owner_user_id')::bigint)
   AND (
       sqlc.arg('include_all')::boolean
       OR (status = 'published' AND visibility = 'public')
@@ -230,12 +232,14 @@ WHERE problem_id = $1;
 -- name: CreateProblemCheckRun :one
 INSERT INTO problem_check_runs (
     problem_id,
+    statement_id,
     testcase_set_id,
     requested_by,
     status,
     summary
 ) VALUES (
     sqlc.arg('problem_id'),
+    sqlc.narg('statement_id'),
     sqlc.narg('testcase_set_id'),
     sqlc.narg('requested_by'),
     sqlc.arg('status'),
@@ -247,6 +251,16 @@ RETURNING *;
 SELECT *
 FROM problem_check_runs
 WHERE id = $1;
+
+-- name: GetLatestCompletedProblemCheckRun :one
+SELECT *
+FROM problem_check_runs
+WHERE problem_id = sqlc.arg('problem_id')
+  AND statement_id = sqlc.arg('statement_id')
+  AND testcase_set_id = sqlc.arg('testcase_set_id')
+  AND status = 'completed'
+ORDER BY finished_at DESC NULLS LAST, id DESC
+LIMIT 1;
 
 -- name: ListProblemCheckRunsByProblemID :many
 SELECT *

--- a/internal/postgres/sqlc.yaml
+++ b/internal/postgres/sqlc.yaml
@@ -2,7 +2,7 @@ version: "2"
 sql:
   - engine: "postgresql"
     schema:
-      - "../migrations/000001_init.up.sql"
+      - "../migrations"
     queries:
       - "queries"
     gen:

--- a/internal/problem/handler.go
+++ b/internal/problem/handler.go
@@ -65,6 +65,11 @@ func (h *Handler) listProblems(c *gin.Context) {
 		httpapi.Error(c, apperror.BadRequest("request.invalid", "page_size must be between 1 and 100"))
 		return
 	}
+	mine, ok := boolQuery(c, "mine", false)
+	if !ok {
+		httpapi.Error(c, apperror.BadRequest("request.invalid", "mine must be a boolean"))
+		return
+	}
 	list, err := h.service.ListProblems(c.Request.Context(), actorFromContext(c), ListProblemsFilter{
 		Difficulty: c.Query("difficulty"),
 		Status:     c.Query("status"),
@@ -73,12 +78,26 @@ func (h *Handler) listProblems(c *gin.Context) {
 		Keyword:    c.Query("keyword"),
 		Page:       page,
 		PageSize:   pageSize,
+		Mine:       mine,
 	})
 	if err != nil {
 		httpapi.Error(c, err)
 		return
 	}
 	httpapi.OK(c, list)
+}
+
+func (h *Handler) getProblemAuthoringState(c *gin.Context) {
+	id, ok := problemIDParam(c)
+	if !ok {
+		return
+	}
+	state, err := h.service.GetProblemAuthoringState(c.Request.Context(), actorFromContext(c), id)
+	if err != nil {
+		httpapi.Error(c, err)
+		return
+	}
+	httpapi.OK(c, state)
 }
 
 func (h *Handler) getProblem(c *gin.Context) {
@@ -344,6 +363,15 @@ func int32Query(c *gin.Context, key string, fallback int32) (int32, bool) {
 		return 0, false
 	}
 	return int32(parsed), true
+}
+
+func boolQuery(c *gin.Context, key string, fallback bool) (bool, bool) {
+	value := c.Query(key)
+	if value == "" {
+		return fallback, true
+	}
+	parsed, err := strconv.ParseBool(value)
+	return parsed, err == nil
 }
 
 func actorFromContext(c *gin.Context) auth.Actor {

--- a/internal/problem/handler_test.go
+++ b/internal/problem/handler_test.go
@@ -166,6 +166,56 @@ func TestUploadTestcasesMissingArchiveReturnsTestcaseNotReady(t *testing.T) {
 	}
 }
 
+func TestGetProblemAuthoringStateReturnsOwnerWorkspace(t *testing.T) {
+	repo := newFakeRepository()
+	seedPublishableProblem(repo)
+	repo.checkRuns[1] = ProblemCheckRunRecord{
+		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
+		Summary: json.RawMessage(`{"valid":true}`),
+	}
+	service := NewService(repo, &fakeStorage{})
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems/1/authoring", nil)
+	req.Header.Set("X-User-ID", "10")
+	req.Header.Set("X-User-Role", "user")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var envelope struct {
+		Data ProblemAuthoringState `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !envelope.Data.Publishable || envelope.Data.Problem.ID != 1 || envelope.Data.LatestCheck == nil {
+		t.Fatalf("unexpected authoring state: %+v", envelope.Data)
+	}
+}
+
+func TestListProblemsMineScopesRequestToCurrentUser(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Title: "Owned", Status: StatusDraft, Visibility: VisibilityPrivate}
+	service := NewService(repo, &fakeStorage{})
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems?mine=true", nil)
+	req.Header.Set("X-User-ID", "10")
+	req.Header.Set("X-User-Role", "user")
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !repo.lastListFilter.Mine || repo.lastListFilter.OwnerUserID != 10 {
+		t.Fatalf("list filter = %+v", repo.lastListFilter)
+	}
+}
+
 func TestCreateProblemStoresTags(t *testing.T) {
 	repo := newFakeRepository()
 	service := NewService(repo, &fakeStorage{})

--- a/internal/problem/repository.go
+++ b/internal/problem/repository.go
@@ -38,6 +38,7 @@ type Repository interface {
 	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
 	CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error)
 	GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error)
+	GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error)
 	ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error)
 	CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error)
 	FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error)
@@ -50,6 +51,7 @@ type Repository interface {
 
 type CreateProblemCheckRunInput struct {
 	ProblemID     int64
+	StatementID   int64
 	TestcaseSetID int64
 	RequestedBy   int64
 	Status        string
@@ -88,6 +90,7 @@ type CreateProblemCheckFindingInput struct {
 type ProblemCheckRunRecord struct {
 	ID            int64           `json:"id"`
 	ProblemID     int64           `json:"problem_id"`
+	StatementID   int64           `json:"statement_id,omitempty"`
 	TestcaseSetID int64           `json:"testcase_set_id,omitempty"`
 	RequestedBy   int64           `json:"requested_by,omitempty"`
 	Status        string          `json:"status"`
@@ -152,6 +155,7 @@ func (r *PostgresRepository) ListProblems(ctx context.Context, filter ListProble
 		Visibility:   textArg(filter.Visibility),
 		Tag:          textArg(filter.Tag),
 		Keyword:      textArg(filter.Keyword),
+		OwnerUserID:  filter.OwnerUserID,
 		IncludeAll:   filter.IncludeAll,
 		ViewerUserID: filter.ViewerUserID,
 		Offset:       filter.Offset,
@@ -174,6 +178,7 @@ func (r *PostgresRepository) CountProblems(ctx context.Context, filter ListProbl
 		Visibility:   textArg(filter.Visibility),
 		Tag:          textArg(filter.Tag),
 		Keyword:      textArg(filter.Keyword),
+		OwnerUserID:  filter.OwnerUserID,
 		IncludeAll:   filter.IncludeAll,
 		ViewerUserID: filter.ViewerUserID,
 	})
@@ -247,6 +252,11 @@ func (r *PostgresRepository) GetProblemCheckRun(ctx context.Context, id int64) (
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }
 
+func (r *PostgresRepository) GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error) {
+	run, err := r.queries.GetLatestCompletedProblemCheckRun(ctx, db.GetLatestCompletedProblemCheckRunParams{ProblemID: problemID, StatementID: int8Value(statementID), TestcaseSetID: int8Value(testcaseSetID)})
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
 func (r *PostgresRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
 	return listProblemCheckRuns(ctx, r.queries, filter)
 }
@@ -315,6 +325,7 @@ func (r *txRepository) ListProblems(ctx context.Context, filter ListProblemsFilt
 		Visibility:   textArg(filter.Visibility),
 		Tag:          textArg(filter.Tag),
 		Keyword:      textArg(filter.Keyword),
+		OwnerUserID:  filter.OwnerUserID,
 		IncludeAll:   filter.IncludeAll,
 		ViewerUserID: filter.ViewerUserID,
 		Offset:       filter.Offset,
@@ -337,6 +348,7 @@ func (r *txRepository) CountProblems(ctx context.Context, filter ListProblemsFil
 		Visibility:   textArg(filter.Visibility),
 		Tag:          textArg(filter.Tag),
 		Keyword:      textArg(filter.Keyword),
+		OwnerUserID:  filter.OwnerUserID,
 		IncludeAll:   filter.IncludeAll,
 		ViewerUserID: filter.ViewerUserID,
 	})
@@ -407,6 +419,11 @@ func (r *txRepository) CreateProblemCheckRun(ctx context.Context, input CreatePr
 
 func (r *txRepository) GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error) {
 	run, err := r.queries.GetProblemCheckRunByID(ctx, id)
+	return problemCheckRunFromDB(run), mapDBErr(err)
+}
+
+func (r *txRepository) GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error) {
+	run, err := r.queries.GetLatestCompletedProblemCheckRun(ctx, db.GetLatestCompletedProblemCheckRunParams{ProblemID: problemID, StatementID: int8Value(statementID), TestcaseSetID: int8Value(testcaseSetID)})
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }
 
@@ -530,6 +547,7 @@ func createProblemCheckRun(ctx context.Context, q *db.Queries, input CreateProbl
 	}
 	run, err := q.CreateProblemCheckRun(ctx, db.CreateProblemCheckRunParams{
 		ProblemID:     input.ProblemID,
+		StatementID:   int8Value(input.StatementID),
 		TestcaseSetID: int8Value(input.TestcaseSetID),
 		RequestedBy:   int8Value(input.RequestedBy),
 		Status:        status,
@@ -729,6 +747,7 @@ func problemCheckRunFromDB(run db.ProblemCheckRun) ProblemCheckRunRecord {
 	return ProblemCheckRunRecord{
 		ID:            run.ID,
 		ProblemID:     run.ProblemID,
+		StatementID:   int8FromDB(run.StatementID),
 		TestcaseSetID: int8FromDB(run.TestcaseSetID),
 		RequestedBy:   int8FromDB(run.RequestedBy),
 		Status:        run.Status,
@@ -763,6 +782,7 @@ func problemCheckRunFromRecord(record ProblemCheckRunRecord) ProblemCheckRun {
 	return ProblemCheckRun{
 		ID:            record.ID,
 		ProblemID:     record.ProblemID,
+		StatementID:   record.StatementID,
 		TestcaseSetID: record.TestcaseSetID,
 		RequestedBy:   record.RequestedBy,
 		Status:        record.Status,

--- a/internal/problem/routes.go
+++ b/internal/problem/routes.go
@@ -15,6 +15,7 @@ func (m *Module) RegisterRoutes(group *gin.RouterGroup) {
 	problems.POST("", m.handler.createProblem)
 	problems.GET("", m.handler.listProblems)
 	problems.GET("/:id", m.handler.getProblem)
+	problems.GET("/:id/authoring", m.handler.getProblemAuthoringState)
 	problems.PATCH("/:id", m.handler.updateProblem)
 	problems.DELETE("/:id", m.handler.archiveProblem)
 	problems.POST("/:id/statement", m.handler.createStatement)

--- a/internal/problem/service.go
+++ b/internal/problem/service.go
@@ -173,7 +173,9 @@ type ListProblemsFilter struct {
 	Limit        int32
 	Offset       int32
 	ViewerUserID int64
+	OwnerUserID  int64
 	IncludeAll   bool
+	Mine         bool
 }
 
 type ProblemList struct {
@@ -225,6 +227,7 @@ type ProblemCheckSummary struct {
 type ProblemCheckRun struct {
 	ID            int64                 `json:"id"`
 	ProblemID     int64                 `json:"problem_id"`
+	StatementID   int64                 `json:"statement_id,omitempty"`
 	TestcaseSetID int64                 `json:"testcase_set_id,omitempty"`
 	RequestedBy   int64                 `json:"requested_by,omitempty"`
 	Status        string                `json:"status"`
@@ -252,6 +255,20 @@ type ProblemCheckFinding struct {
 type ProblemCheckResult struct {
 	Run      ProblemCheckRun       `json:"run"`
 	Findings []ProblemCheckFinding `json:"findings"`
+}
+
+type ProblemAuthoringBlocker struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type ProblemAuthoringState struct {
+	Problem     ProblemResponse           `json:"problem"`
+	Statement   *Statement                `json:"statement"`
+	TestcaseSet *TestcaseSetRecord        `json:"testcase_set"`
+	LatestCheck *ProblemCheckRun          `json:"latest_check"`
+	Publishable bool                      `json:"publishable"`
+	Blockers    []ProblemAuthoringBlocker `json:"blockers"`
 }
 
 type Service struct {
@@ -302,6 +319,9 @@ func (s *Service) GetProblem(ctx context.Context, actor auth.Actor, id int64) (P
 }
 
 func (s *Service) ListProblems(ctx context.Context, actor auth.Actor, filter ListProblemsFilter) (ProblemList, error) {
+	if filter.Mine && !actor.Authenticated() {
+		return ProblemList{}, requireAuthenticated(actor)
+	}
 	filter = normalizeListFilter(actor, filter)
 	items, err := s.repo.ListProblems(ctx, filter)
 	if err != nil {
@@ -320,6 +340,32 @@ func (s *Service) ListProblems(ctx context.Context, actor auth.Actor, filter Lis
 		responses = append(responses, response)
 	}
 	return ProblemList{Items: responses, Total: total, Page: filter.Page, PageSize: filter.PageSize}, nil
+}
+
+func (s *Service) GetProblemAuthoringState(ctx context.Context, actor auth.Actor, id int64) (ProblemAuthoringState, error) {
+	p, err := s.repo.GetProblem(ctx, id)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	response, err := s.ProblemResponse(ctx, p)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	readiness, err := loadProblemAuthoringReadiness(ctx, s.repo, id)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	return ProblemAuthoringState{
+		Problem:     response,
+		Statement:   readiness.statement,
+		TestcaseSet: readiness.testcaseSet,
+		LatestCheck: readiness.latestCheck,
+		Publishable: len(readiness.blockers) == 0,
+		Blockers:    readiness.blockers,
+	}, nil
 }
 
 func (s *Service) UpdateProblem(ctx context.Context, actor auth.Actor, id int64, input UpdateProblemInput) (ProblemRecord, error) {
@@ -398,7 +444,10 @@ func (s *Service) CreateStatement(ctx context.Context, actor auth.Actor, problem
 			}
 		}
 		statement, err = repo.CreateProblemStatement(ctx, problemID, version, input)
-		return err
+		if err != nil {
+			return err
+		}
+		return demotePublishedProblem(ctx, repo, p)
 	})
 	return statement, err
 }
@@ -502,7 +551,10 @@ func (s *Service) UploadTestcaseArchive(ctx context.Context, actor auth.Actor, p
 			return err
 		}
 		created, err = repo.CreateTestcaseSet(ctx, problemID, version, key, actualChecksum, int64(len(input.Content)), input.CaseCount, actor.UserID)
-		return err
+		if err != nil {
+			return err
+		}
+		return demotePublishedProblem(ctx, repo, p)
 	})
 	if err != nil {
 		_ = s.storage.Delete(ctx, key)
@@ -585,6 +637,7 @@ func (s *Service) RunProblemCheck(ctx context.Context, actor auth.Actor, problem
 	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
 		run, err := repo.CreateProblemCheckRun(ctx, CreateProblemCheckRunInput{
 			ProblemID:     problemID,
+			StatementID:   statement.ID,
 			TestcaseSetID: set.ID,
 			RequestedBy:   actor.UserID,
 			Status:        ProblemCheckStatusRunning,
@@ -753,13 +806,85 @@ func (s *Service) Stats(ctx context.Context, actor auth.Actor, problemID int64) 
 }
 
 func ensurePublishable(ctx context.Context, repo Repository, problemID int64) error {
-	if _, err := repo.GetCurrentProblemStatement(ctx, problemID); err != nil {
-		return apperror.Unprocessable("problem.not_publishable", "current statement is required before publishing")
+	readiness, err := loadProblemAuthoringReadiness(ctx, repo, problemID)
+	if err != nil {
+		return err
 	}
-	if _, err := repo.GetCurrentReadyTestcaseSet(ctx, problemID); err != nil {
-		return apperror.Unprocessable("problem.not_publishable", "current ready testcase set is required before publishing")
+	if len(readiness.blockers) > 0 {
+		blocker := readiness.blockers[0]
+		return apperror.Unprocessable(blocker.Code, blocker.Message)
 	}
 	return nil
+}
+
+func demotePublishedProblem(ctx context.Context, repo Repository, problem ProblemRecord) error {
+	if problem.Status != StatusPublished {
+		return nil
+	}
+	status := StatusDraft
+	_, err := repo.UpdateProblem(ctx, problem.ID, UpdateProblemInput{Status: &status})
+	return err
+}
+
+type problemAuthoringReadiness struct {
+	statement   *Statement
+	testcaseSet *TestcaseSetRecord
+	latestCheck *ProblemCheckRun
+	blockers    []ProblemAuthoringBlocker
+}
+
+func loadProblemAuthoringReadiness(ctx context.Context, repo Repository, problemID int64) (problemAuthoringReadiness, error) {
+	state := problemAuthoringReadiness{blockers: []ProblemAuthoringBlocker{}}
+	statement, err := repo.GetCurrentProblemStatement(ctx, problemID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.statement_required", Message: "current statement is required before publishing"})
+	} else {
+		state.statement = &statement
+	}
+
+	testcaseSet, err := repo.GetCurrentReadyTestcaseSet(ctx, problemID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.testcase_required", Message: "current ready testcase set is required before publishing"})
+		return state, nil
+	}
+	state.testcaseSet = &testcaseSet
+
+	if state.statement == nil {
+		return state, nil
+	}
+	runRecord, err := repo.GetLatestCompletedProblemCheckRun(ctx, problemID, state.statement.ID, testcaseSet.ID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_required", Message: "run a problem check for the current testcase set before publishing"})
+		return state, nil
+	}
+	run := problemCheckRunFromRecord(runRecord)
+	findings, err := repo.ListProblemCheckFindings(ctx, run.ID)
+	if err != nil {
+		return problemAuthoringReadiness{}, err
+	}
+	run.Findings = make([]ProblemCheckFinding, 0, len(findings))
+	for _, finding := range findings {
+		run.Findings = append(run.Findings, problemCheckFindingFromRecord(finding))
+	}
+	state.latestCheck = &run
+	if !run.Summary.Valid {
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_failed", Message: "the current testcase set has validation errors"})
+	}
+	return state, nil
+}
+
+func isNotFoundError(err error) bool {
+	appErr, ok := apperror.From(err)
+	return ok && appErr.HTTPStatus == http.StatusNotFound
 }
 
 type problemCheckFindingDraft struct {
@@ -978,6 +1103,7 @@ func serviceProblemCheckRunFromRecord(record ProblemCheckRunRecord) ProblemCheck
 	return ProblemCheckRun{
 		ID:            record.ID,
 		ProblemID:     record.ProblemID,
+		StatementID:   record.StatementID,
 		TestcaseSetID: record.TestcaseSetID,
 		RequestedBy:   record.RequestedBy,
 		Status:        record.Status,
@@ -1162,6 +1288,12 @@ func normalizeListFilter(actor auth.Actor, filter ListProblemsFilter) ListProble
 	}
 	filter.Limit = filter.PageSize
 	filter.Offset = (filter.Page - 1) * filter.PageSize
+	if filter.Mine && actor.Authenticated() {
+		filter.OwnerUserID = actor.UserID
+		filter.ViewerUserID = actor.UserID
+		filter.IncludeAll = false
+		return filter
+	}
 	if actor.Admin() {
 		filter.IncludeAll = true
 		return filter

--- a/internal/problem/service_test.go
+++ b/internal/problem/service_test.go
@@ -21,7 +21,8 @@ import (
 func TestProblemAuthorizationAllowsOwnerAndAdmin(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	store := &fakeStorage{}
+	service := NewService(repo, store)
 	title := "Updated"
 
 	_, err := service.UpdateProblem(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1, UpdateProblemInput{Title: &title})
@@ -32,6 +33,185 @@ func TestProblemAuthorizationAllowsOwnerAndAdmin(t *testing.T) {
 	}
 	if _, err := service.UpdateProblem(context.Background(), auth.Actor{UserID: 99, Role: auth.RoleAdmin}, 1, UpdateProblemInput{Title: &title}); err != nil {
 		t.Fatalf("admin update failed: %v", err)
+	}
+}
+
+func TestPublishRequiresValidCheckForCurrentTestcaseSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		seedRun  *ProblemCheckRunRecord
+		wantCode string
+	}{
+		{name: "missing check", wantCode: "problem.check_required"},
+		{
+			name: "check belongs to previous testcase set",
+			seedRun: &ProblemCheckRunRecord{
+				ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 6, Status: ProblemCheckStatusCompleted,
+				Summary: json.RawMessage(`{"valid":true}`),
+			},
+			wantCode: "problem.check_required",
+		},
+		{
+			name: "current check has errors",
+			seedRun: &ProblemCheckRunRecord{
+				ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
+				Summary: json.RawMessage(`{"valid":false,"error_count":1}`),
+			},
+			wantCode: "problem.check_failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newFakeRepository()
+			seedPublishableProblem(repo)
+			if tt.seedRun != nil {
+				repo.checkRuns[tt.seedRun.ID] = *tt.seedRun
+			}
+			service := NewService(repo, &fakeStorage{})
+			status := StatusPublished
+
+			_, err := service.UpdateProblem(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UpdateProblemInput{Status: &status})
+
+			assertAppCode(t, err, tt.wantCode)
+		})
+	}
+}
+
+func TestPublishAllowsValidCheckForCurrentTestcaseSet(t *testing.T) {
+	repo := newFakeRepository()
+	seedPublishableProblem(repo)
+	repo.checkRuns[1] = ProblemCheckRunRecord{
+		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
+		Summary: json.RawMessage(`{"valid":true,"error_count":0}`),
+	}
+	service := NewService(repo, &fakeStorage{})
+	status := StatusPublished
+
+	updated, err := service.UpdateProblem(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UpdateProblemInput{Status: &status})
+
+	if err != nil {
+		t.Fatalf("UpdateProblem returned error: %v", err)
+	}
+	if updated.Status != StatusPublished {
+		t.Fatalf("status = %q, want %q", updated.Status, StatusPublished)
+	}
+}
+
+func TestSavingNewStatementInvalidatesPreviousValidCheck(t *testing.T) {
+	repo := newFakeRepository()
+	seedPublishableProblem(repo)
+	repo.nextStatementID = 3
+	repo.checkRuns[1] = ProblemCheckRunRecord{
+		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
+		Summary: json.RawMessage(`{"valid":true,"error_count":0}`),
+	}
+	store := &fakeStorage{}
+	service := NewService(repo, store)
+	actor := auth.Actor{UserID: 10, Role: auth.RoleUser}
+
+	statement, err := service.CreateStatement(t.Context(), actor, 1, CreateStatementInput{
+		Title:       "Updated statement",
+		Description: "updated description",
+		MakeCurrent: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateStatement returned error: %v", err)
+	}
+	if statement.ID == 3 {
+		t.Fatalf("statement ID = %d, want a new version", statement.ID)
+	}
+
+	state, err := service.GetProblemAuthoringState(t.Context(), actor, 1)
+	if err != nil {
+		t.Fatalf("GetProblemAuthoringState returned error: %v", err)
+	}
+	if state.Publishable || state.LatestCheck != nil {
+		t.Fatalf("new statement reused previous check: %+v", state)
+	}
+	if got := blockerCodes(state.Blockers); strings.Join(got, ",") != "problem.check_required" {
+		t.Fatalf("blockers = %v, want problem.check_required", got)
+	}
+
+	status := StatusPublished
+	_, err = service.UpdateProblem(t.Context(), actor, 1, UpdateProblemInput{Status: &status})
+	assertAppCode(t, err, "problem.check_required")
+
+	store.objects = map[string][]byte{"cases.zip": zipArchive(t, map[string]string{
+		"input1.txt":  "1\n",
+		"output1.txt": "1\n",
+	})}
+	check, err := service.RunProblemCheck(t.Context(), actor, 1)
+	if err != nil {
+		t.Fatalf("RunProblemCheck returned error: %v", err)
+	}
+	if check.Run.StatementID != statement.ID || !check.Run.Summary.Valid {
+		t.Fatalf("new check = %+v, want valid check for statement %d", check.Run, statement.ID)
+	}
+
+	updated, err := service.UpdateProblem(t.Context(), actor, 1, UpdateProblemInput{Status: &status})
+	if err != nil {
+		t.Fatalf("publishing after current check returned error: %v", err)
+	}
+	if updated.Status != StatusPublished {
+		t.Fatalf("status = %q, want %q", updated.Status, StatusPublished)
+	}
+}
+
+func TestProblemAuthoringStateReportsPublishBlockers(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
+	service := NewService(repo, &fakeStorage{})
+
+	state, err := service.GetProblemAuthoringState(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
+
+	if err != nil {
+		t.Fatalf("GetProblemAuthoringState returned error: %v", err)
+	}
+	if state.Publishable || state.Statement != nil || state.TestcaseSet != nil || state.LatestCheck != nil {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+	if got := blockerCodes(state.Blockers); strings.Join(got, ",") != "problem.statement_required,problem.testcase_required" {
+		t.Fatalf("blockers = %v", got)
+	}
+}
+
+func TestProblemAuthoringStateReturnsCurrentValidCheck(t *testing.T) {
+	repo := newFakeRepository()
+	seedPublishableProblem(repo)
+	repo.checkRuns[1] = ProblemCheckRunRecord{
+		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
+		Summary: json.RawMessage(`{"valid":true}`),
+	}
+	service := NewService(repo, &fakeStorage{})
+
+	state, err := service.GetProblemAuthoringState(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
+
+	if err != nil {
+		t.Fatalf("GetProblemAuthoringState returned error: %v", err)
+	}
+	if !state.Publishable || state.Statement == nil || state.TestcaseSet == nil || state.LatestCheck == nil {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+	if len(state.Blockers) != 0 || state.LatestCheck.TestcaseSetID != 7 {
+		t.Fatalf("unexpected blockers/check: %+v", state)
+	}
+}
+
+func TestListProblemsMineRequiresAuthentication(t *testing.T) {
+	repo := newFakeRepository()
+	service := NewService(repo, &fakeStorage{})
+
+	_, err := service.ListProblems(t.Context(), auth.Actor{}, ListProblemsFilter{Mine: true})
+
+	assertAppCode(t, err, "auth.required")
+}
+
+func TestNormalizeListFilterScopesMineToActor(t *testing.T) {
+	filter := normalizeListFilter(auth.Actor{UserID: 10, Role: auth.RoleAdmin}, ListProblemsFilter{Mine: true})
+
+	if filter.OwnerUserID != 10 || filter.IncludeAll {
+		t.Fatalf("mine filter = %+v", filter)
 	}
 }
 
@@ -58,6 +238,21 @@ func TestCreateStatementSwitchesCurrentVersion(t *testing.T) {
 	}
 	if !repo.statements[second.ID].IsCurrent || repo.currentStatement[1] != second.ID {
 		t.Fatalf("second statement should be current")
+	}
+}
+
+func TestCreateStatementDemotesPublishedProblemToDraft(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusPublished, Visibility: VisibilityPublic}
+	service := NewService(repo, &fakeStorage{})
+
+	_, err := service.CreateStatement(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, CreateStatementInput{Title: "Updated", Description: "desc"})
+
+	if err != nil {
+		t.Fatalf("CreateStatement returned error: %v", err)
+	}
+	if got := repo.problems[1].Status; got != StatusDraft {
+		t.Fatalf("problem status = %q, want draft", got)
 	}
 }
 
@@ -116,6 +311,22 @@ func TestUploadTestcaseArchiveDeletesObjectWhenTransactionFails(t *testing.T) {
 	}
 	if len(store.deletes) != 1 {
 		t.Fatalf("expected uploaded object to be deleted after transaction failure, got deletes=%v", store.deletes)
+	}
+}
+
+func TestUploadTestcaseArchiveDemotesPublishedProblemToDraft(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusPublished, Visibility: VisibilityPublic}
+	service := NewService(repo, &fakeStorage{})
+	archive := zipArchive(t, map[string]string{"input1.txt": "1\n", "output1.txt": "1\n"})
+
+	_, err := service.UploadTestcaseArchive(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UploadTestcaseInput{Content: archive, CaseCount: 1, ChecksumSHA256: sha256Hex(archive)})
+
+	if err != nil {
+		t.Fatalf("UploadTestcaseArchive returned error: %v", err)
+	}
+	if got := repo.problems[1].Status; got != StatusDraft {
+		t.Fatalf("problem status = %q, want draft", got)
 	}
 }
 
@@ -397,6 +608,23 @@ func seedProblemCheckData(t *testing.T, repo *fakeRepository, store *fakeStorage
 	}
 }
 
+func seedPublishableProblem(repo *fakeRepository) {
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate, CurrentStatementID: 3, CurrentTestcaseSetID: 7, CurrentTestcaseStatus: TestcaseStatusReady}
+	repo.statements[3] = Statement{ID: 3, ProblemID: 1, Version: 1, Title: "A", Description: "desc", Samples: json.RawMessage(`[]`), IsCurrent: true}
+	repo.currentStatement[1] = 3
+	repo.testcaseSets[7] = TestcaseSetRecord{ID: 7, ProblemID: 1, Version: 1, StorageKey: "cases.zip", CaseCount: 1, Status: TestcaseStatusReady, IsCurrent: true}
+	repo.currentTestcase[1] = 7
+}
+
+func blockerCodes(blockers []ProblemAuthoringBlocker) []string {
+	codes := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		codes = append(codes, blocker.Code)
+	}
+	sort.Strings(codes)
+	return codes
+}
+
 func assertFindingCodes(t *testing.T, findings []ProblemCheckFinding, want []string) {
 	t.Helper()
 	got := make([]string, 0, len(findings))
@@ -432,6 +660,7 @@ type fakeRepository struct {
 	nextCheckFindingID    int64
 	nextArtifactID        int64
 	failCreateTestcaseSet bool
+	lastListFilter        ListProblemsFilter
 }
 
 func newFakeRepository() *fakeRepository {
@@ -479,11 +708,21 @@ func (r *fakeRepository) GetProblem(ctx context.Context, id int64) (ProblemRecor
 }
 
 func (r *fakeRepository) ListProblems(ctx context.Context, filter ListProblemsFilter) ([]ProblemRecord, error) {
-	return nil, errors.New("not implemented")
+	r.lastListFilter = filter
+	items := make([]ProblemRecord, 0)
+	for _, problem := range r.problems {
+		if filter.OwnerUserID > 0 && problem.OwnerUserID != filter.OwnerUserID {
+			continue
+		}
+		items = append(items, problem)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].ID > items[j].ID })
+	return items, nil
 }
 
 func (r *fakeRepository) CountProblems(ctx context.Context, filter ListProblemsFilter) (int64, error) {
-	return 0, errors.New("not implemented")
+	items, err := r.ListProblems(ctx, filter)
+	return int64(len(items)), err
 }
 
 func (r *fakeRepository) UpdateProblem(ctx context.Context, id int64, input UpdateProblemInput) (ProblemRecord, error) {
@@ -629,6 +868,7 @@ func (r *fakeRepository) CreateProblemCheckRun(ctx context.Context, input Create
 	run := ProblemCheckRunRecord{
 		ID:            r.nextCheckRunID,
 		ProblemID:     input.ProblemID,
+		StatementID:   input.StatementID,
 		TestcaseSetID: input.TestcaseSetID,
 		RequestedBy:   input.RequestedBy,
 		Status:        status,
@@ -646,6 +886,22 @@ func (r *fakeRepository) GetProblemCheckRun(ctx context.Context, id int64) (Prob
 		return ProblemCheckRunRecord{}, apperror.NotFound("problem.not_found", "problem not found")
 	}
 	return run, nil
+}
+
+func (r *fakeRepository) GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error) {
+	var latest ProblemCheckRunRecord
+	for _, run := range r.checkRuns {
+		if run.ProblemID != problemID || run.StatementID != statementID || run.TestcaseSetID != testcaseSetID || run.Status != ProblemCheckStatusCompleted {
+			continue
+		}
+		if latest.ID == 0 || run.FinishedAt.After(latest.FinishedAt) || (run.FinishedAt.Equal(latest.FinishedAt) && run.ID > latest.ID) {
+			latest = run
+		}
+	}
+	if latest.ID == 0 {
+		return ProblemCheckRunRecord{}, apperror.NotFound("problem_check.not_found", "problem check not found")
+	}
+	return latest, nil
 }
 
 func (r *fakeRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {


### PR DESCRIPTION
## Summary

- add an owner/admin authoring-state endpoint and authenticated `mine=true` problem listing
- require a completed valid check for the exact current statement and testcase-set pair before publication
- demote published problems to draft when statement or testcase content changes
- add migration, OpenAPI/API guide updates, regression coverage, and smoke validation

## Integration

This is the backend half of the SOJ problem authoring workspace. Merge and deploy this PR before the linked SOJ-web PR.

Frontend PR: https://github.com/sparklyi/SOJ-web/pull/35

## Verification

- `go test ./...`
- `go vet ./...`
- `npx --yes @redocly/cli@1.34.5 lint api/openapi.yaml`
- `docker compose -f deploy/docker-compose.yaml config`
- `docker compose -f deploy/docker-compose.yaml -f deploy/docker-compose.docker-runner.yaml config`
- migration container applied `000002_problem_check_statement.up.sql`
- `make smoke`
- real SOJ-web HTTP Playwright authoring flow, including stale-statement check rejection
