### PR TITLE
fix(contest): recompute score projection from submissions

### DIFF
--- a/docs/superpowers/cases/2026-07-13-contest-projection-recompute-bug-repro.md
+++ b/docs/superpowers/cases/2026-07-13-contest-projection-recompute-bug-repro.md
@@ -1,0 +1,155 @@
+# Contest Projection Recompute Bug Repro Cases
+
+Source:
+- GitHub issue #28
+- `internal/submission/repository.go`
+- `internal/contest/submission.go`
+
+## Structured Output
+
+```yaml
+analysis:
+  bug_class: state-consistency
+  affected_layers:
+    - service
+    - storage
+  root_cause_summary: >-
+    Contest problem results are incrementally updated in judge completion order and
+    short-circuit when the current projection is accepted or references the same
+    submission. The projection therefore does not reflect submission order or a
+    rejudged submission's current verdict.
+  missing_information: []
+  reproducibility:
+    status: reproducible
+    blockers: []
+
+coverage_plan:
+  obligations:
+    - trigger_bug
+    - prove_before_fail
+    - prove_after_pass
+    - cover_service_surface
+  selected_cases:
+    - out_of_order_completion
+    - rejudge_replaces_current_verdict
+
+cases:
+  - case_id: out_of_order_completion
+    purpose: trigger
+    target_layer: service
+    minimality_reason: >-
+      Two submissions are the smallest sequence that proves judge completion order
+      must not determine ACM attempts or penalty.
+    input:
+      http: {}
+      service:
+        function: buildContestProblemProjection
+        args: >-
+          Contest starts at 10:00. Submission 1 is wrong_answer at 10:10 and
+          submission 2 is accepted at 10:20, supplied in completion order 2 then 1.
+      fixtures:
+        db: Two current terminal submission rows with their current attempt ids.
+        es: not-needed
+        redis: not-needed
+        files: not-needed
+        network: not-needed
+    isolation:
+      db: fixture
+      es: not-needed
+      doris: not-needed
+      redis: not-needed
+      file_io: not-needed
+      network: not-needed
+    before_expectation:
+      outcome: wrong-state
+      assertion: "attempts == 1 and penalty_minutes == 20"
+    after_expectation:
+      outcome: pass
+      assertion: "status == accepted and attempts == 2 and penalty_minutes == 40 and last_submission_id == 2"
+    obligations_covered:
+      - trigger_bug
+      - prove_before_fail
+      - prove_after_pass
+      - cover_service_surface
+
+  - case_id: rejudge_replaces_current_verdict
+    purpose: guard
+    target_layer: service
+    minimality_reason: >-
+      One submission whose current verdict changes is sufficient to prove the
+      projection must be rebuilt instead of skipped by submission id.
+    input:
+      http: {}
+      service:
+        function: buildContestProblemProjection
+        args: >-
+          One submission currently has wrong_answer after rejudge and points to the
+          new current attempt.
+      fixtures:
+        db: One current terminal submission row after accepted was rejudged to wrong_answer.
+        es: not-needed
+        redis: not-needed
+        files: not-needed
+        network: not-needed
+    isolation:
+      db: fixture
+      es: not-needed
+      doris: not-needed
+      redis: not-needed
+      file_io: not-needed
+      network: not-needed
+    before_expectation:
+      outcome: wrong-state
+      assertion: "projection remains accepted because last_submission_id matches"
+    after_expectation:
+      outcome: pass
+      assertion: "status == attempted and attempts == 1 and accepted_at is null and last_attempt_id is the rejudge attempt"
+    obligations_covered:
+      - trigger_bug
+      - prove_before_fail
+      - prove_after_pass
+      - cover_service_surface
+
+executors:
+  http_reproducer:
+    needed: false
+    strategy: none
+    target_files: []
+    setup_notes:
+      - The defect is in transaction-local projection calculation, below the HTTP boundary.
+  service_reproducer:
+    needed: true
+    strategy: direct-call
+    target_files:
+      - internal/submission/contest_projection_test.go
+      - internal/submission/repository.go
+      - internal/postgres/queries/submissions.sql
+    setup_notes:
+      - Use a pure projection builder for deterministic fail-before and pass-after assertions.
+      - Verify SQL separately keeps the rebuild inside the submission completion transaction.
+
+minimization:
+  core_case: out_of_order_completion
+  removed_candidates:
+    - case_id: accepted_then_later_wrong
+      removal_reason: same-path
+    - case_id: historical_wrong_rejudged_accepted
+      removal_reason: same-obligation
+  final_case_count: 2
+
+handoff:
+  artifact_path: docs/superpowers/cases/2026-07-13-contest-projection-recompute-bug-repro.md
+  summary: >-
+    Recompute each contest user/problem projection from current terminal submissions
+    ordered by submission time, and serialize concurrent recomputations per projection.
+  next_goal: >-
+    Replace completion-order incremental updates with a transactionally locked rebuild
+    that uses current submission_results attempt links and supports rejudge replacement.
+  suggested_skills:
+    - go-feature-change-review
+    - git-commit-push-pr
+  verification_focus:
+    - out_of_order_completion
+    - rejudge_replaces_current_verdict
+    - concurrent completions cannot overwrite a projection with a partial view
+```

--- a/internal/postgres/db/querier.go
+++ b/internal/postgres/db/querier.go
@@ -53,6 +53,7 @@ type Querier interface {
 	// Owner: WP2 Auth/User
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	DeleteContestProblems(ctx context.Context, contestID int64) error
+	EnsureContestProblemResultProjection(ctx context.Context, arg EnsureContestProblemResultProjectionParams) error
 	FailActiveRejudgeBatchItemByTaskID(ctx context.Context, arg FailActiveRejudgeBatchItemByTaskIDParams) (RejudgeBatchItem, error)
 	FailProblemCheckRun(ctx context.Context, arg FailProblemCheckRunParams) (ProblemCheckRun, error)
 	FailRejudgeBatch(ctx context.Context, arg FailRejudgeBatchParams) (RejudgeBatch, error)
@@ -87,6 +88,7 @@ type Querier interface {
 	GetUserByID(ctx context.Context, id int64) (User, error)
 	LinkProblemTag(ctx context.Context, arg LinkProblemTagParams) error
 	ListContestProblemResults(ctx context.Context, contestID int64) ([]ContestProblemResult, error)
+	ListContestProblemSubmissionsForProjection(ctx context.Context, arg ListContestProblemSubmissionsForProjectionParams) ([]ListContestProblemSubmissionsForProjectionRow, error)
 	ListContestProblems(ctx context.Context, contestID int64) ([]ListContestProblemsRow, error)
 	ListContestRegistrations(ctx context.Context, arg ListContestRegistrationsParams) ([]ContestRegistration, error)
 	ListContestScoreSnapshotCandidates(ctx context.Context, arg ListContestScoreSnapshotCandidatesParams) ([]ListContestScoreSnapshotCandidatesRow, error)
@@ -106,6 +108,7 @@ type Querier interface {
 	ListRejudgeBatches(ctx context.Context, arg ListRejudgeBatchesParams) ([]RejudgeBatch, error)
 	ListSubmissions(ctx context.Context, arg ListSubmissionsParams) ([]Submission, error)
 	ListUsers(ctx context.Context, arg ListUsersParams) ([]User, error)
+	LockContestProblemResultProjection(ctx context.Context, arg LockContestProblemResultProjectionParams) (ContestProblemResult, error)
 	LockProblemForUpdate(ctx context.Context, id int64) (LockProblemForUpdateRow, error)
 	MarkJudgeAttemptFinished(ctx context.Context, arg MarkJudgeAttemptFinishedParams) (JudgeAttempt, error)
 	MarkJudgeTaskDead(ctx context.Context, arg MarkJudgeTaskDeadParams) (JudgeTask, error)

--- a/internal/postgres/db/submissions.sql.go
+++ b/internal/postgres/db/submissions.sql.go
@@ -882,6 +882,36 @@ func (q *Queries) CreateSubmission(ctx context.Context, arg CreateSubmissionPara
 	return i, err
 }
 
+const ensureContestProblemResultProjection = `-- name: EnsureContestProblemResultProjection :exec
+INSERT INTO contest_problem_results (
+    contest_id,
+    user_id,
+    problem_id,
+    status,
+    attempts,
+    penalty_minutes
+) VALUES (
+    $1,
+    $2,
+    $3,
+    'none',
+    0,
+    0
+)
+ON CONFLICT (contest_id, user_id, problem_id) DO NOTHING
+`
+
+type EnsureContestProblemResultProjectionParams struct {
+	ContestID int64 `db:"contest_id" json:"contest_id"`
+	UserID    int64 `db:"user_id" json:"user_id"`
+	ProblemID int64 `db:"problem_id" json:"problem_id"`
+}
+
+func (q *Queries) EnsureContestProblemResultProjection(ctx context.Context, arg EnsureContestProblemResultProjectionParams) error {
+	_, err := q.db.Exec(ctx, ensureContestProblemResultProjection, arg.ContestID, arg.UserID, arg.ProblemID)
+	return err
+}
+
 const failActiveRejudgeBatchItemByTaskID = `-- name: FailActiveRejudgeBatchItemByTaskID :one
 UPDATE rejudge_batch_items
 SET status = 'failed',
@@ -1407,6 +1437,58 @@ func (q *Queries) GetSubmissionResultBySubmissionID(ctx context.Context, submiss
 	return i, err
 }
 
+const listContestProblemSubmissionsForProjection = `-- name: ListContestProblemSubmissionsForProjection :many
+SELECT s.id,
+       s.status,
+       s.submitted_at,
+       sr.attempt_id
+FROM submissions s
+LEFT JOIN submission_results sr ON sr.submission_id = s.id
+WHERE s.contest_id = $1
+  AND s.user_id = $2
+  AND s.problem_id = $3
+  AND s.status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'output_limit', 'system_error', 'canceled')
+ORDER BY s.submitted_at, s.id
+`
+
+type ListContestProblemSubmissionsForProjectionParams struct {
+	ContestID pgtype.Int8 `db:"contest_id" json:"contest_id"`
+	UserID    int64       `db:"user_id" json:"user_id"`
+	ProblemID int64       `db:"problem_id" json:"problem_id"`
+}
+
+type ListContestProblemSubmissionsForProjectionRow struct {
+	ID          int64              `db:"id" json:"id"`
+	Status      string             `db:"status" json:"status"`
+	SubmittedAt pgtype.Timestamptz `db:"submitted_at" json:"submitted_at"`
+	AttemptID   pgtype.Int8        `db:"attempt_id" json:"attempt_id"`
+}
+
+func (q *Queries) ListContestProblemSubmissionsForProjection(ctx context.Context, arg ListContestProblemSubmissionsForProjectionParams) ([]ListContestProblemSubmissionsForProjectionRow, error) {
+	rows, err := q.db.Query(ctx, listContestProblemSubmissionsForProjection, arg.ContestID, arg.UserID, arg.ProblemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListContestProblemSubmissionsForProjectionRow
+	for rows.Next() {
+		var i ListContestProblemSubmissionsForProjectionRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Status,
+			&i.SubmittedAt,
+			&i.AttemptID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEligibleContestSubmissionsForRejudge = `-- name: ListEligibleContestSubmissionsForRejudge :many
 SELECT id, user_id, problem_id, contest_id, language_id, testcase_set_id, status, source_artifact_id, time_ms, memory_kb, score, error_message, submitted_at, judged_at, updated_at
 FROM submissions
@@ -1837,6 +1919,41 @@ func (q *Queries) ListSubmissions(ctx context.Context, arg ListSubmissionsParams
 		return nil, err
 	}
 	return items, nil
+}
+
+const lockContestProblemResultProjection = `-- name: LockContestProblemResultProjection :one
+SELECT contest_id, user_id, problem_id, status, attempts, accepted_at, penalty_minutes, last_submission_id, best_submission_id, best_attempt_id, last_attempt_id, updated_at
+FROM contest_problem_results
+WHERE contest_id = $1
+  AND user_id = $2
+  AND problem_id = $3
+FOR UPDATE
+`
+
+type LockContestProblemResultProjectionParams struct {
+	ContestID int64 `db:"contest_id" json:"contest_id"`
+	UserID    int64 `db:"user_id" json:"user_id"`
+	ProblemID int64 `db:"problem_id" json:"problem_id"`
+}
+
+func (q *Queries) LockContestProblemResultProjection(ctx context.Context, arg LockContestProblemResultProjectionParams) (ContestProblemResult, error) {
+	row := q.db.QueryRow(ctx, lockContestProblemResultProjection, arg.ContestID, arg.UserID, arg.ProblemID)
+	var i ContestProblemResult
+	err := row.Scan(
+		&i.ContestID,
+		&i.UserID,
+		&i.ProblemID,
+		&i.Status,
+		&i.Attempts,
+		&i.AcceptedAt,
+		&i.PenaltyMinutes,
+		&i.LastSubmissionID,
+		&i.BestSubmissionID,
+		&i.BestAttemptID,
+		&i.LastAttemptID,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const markJudgeAttemptFinished = `-- name: MarkJudgeAttemptFinished :one

--- a/internal/postgres/db/submissions_sql_test.go
+++ b/internal/postgres/db/submissions_sql_test.go
@@ -153,6 +153,29 @@ func TestContestProjectionReferencesJudgeAttempts(t *testing.T) {
 	}
 }
 
+func TestContestProjectionQueriesSerializeAndRebuildFromCurrentResults(t *testing.T) {
+	for _, want := range []string{
+		"INSERT INTO contest_problem_results",
+		"ON CONFLICT (contest_id, user_id, problem_id) DO NOTHING",
+	} {
+		if !strings.Contains(ensureContestProblemResultProjection, want) {
+			t.Fatalf("EnsureContestProblemResultProjection missing %q:\n%s", want, ensureContestProblemResultProjection)
+		}
+	}
+	if !strings.Contains(lockContestProblemResultProjection, "FOR UPDATE") {
+		t.Fatalf("LockContestProblemResultProjection must serialize projection rebuilds:\n%s", lockContestProblemResultProjection)
+	}
+	for _, want := range []string{
+		"LEFT JOIN submission_results sr ON sr.submission_id = s.id",
+		"s.status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'output_limit', 'system_error', 'canceled')",
+		"ORDER BY s.submitted_at, s.id",
+	} {
+		if !strings.Contains(listContestProblemSubmissionsForProjection, want) {
+			t.Fatalf("ListContestProblemSubmissionsForProjection missing %q:\n%s", want, listContestProblemSubmissionsForProjection)
+		}
+	}
+}
+
 func TestJudgeResultQueriesExposeAttemptsCasesAndProjection(t *testing.T) {
 	for name, query := range map[string]string{
 		"CreateJudgeAttempt":                  createJudgeAttempt,

--- a/internal/postgres/queries/submissions.sql
+++ b/internal/postgres/queries/submissions.sql
@@ -274,6 +274,45 @@ WHERE (sqlc.narg('user_id')::bigint IS NULL OR user_id = sqlc.narg('user_id')::b
   AND (sqlc.narg('contest_id')::bigint IS NULL OR contest_id = sqlc.narg('contest_id')::bigint)
   AND (sqlc.narg('status')::text IS NULL OR status = sqlc.narg('status')::text);
 
+-- name: EnsureContestProblemResultProjection :exec
+INSERT INTO contest_problem_results (
+    contest_id,
+    user_id,
+    problem_id,
+    status,
+    attempts,
+    penalty_minutes
+) VALUES (
+    sqlc.arg('contest_id'),
+    sqlc.arg('user_id'),
+    sqlc.arg('problem_id'),
+    'none',
+    0,
+    0
+)
+ON CONFLICT (contest_id, user_id, problem_id) DO NOTHING;
+
+-- name: LockContestProblemResultProjection :one
+SELECT *
+FROM contest_problem_results
+WHERE contest_id = sqlc.arg('contest_id')
+  AND user_id = sqlc.arg('user_id')
+  AND problem_id = sqlc.arg('problem_id')
+FOR UPDATE;
+
+-- name: ListContestProblemSubmissionsForProjection :many
+SELECT s.id,
+       s.status,
+       s.submitted_at,
+       sr.attempt_id
+FROM submissions s
+LEFT JOIN submission_results sr ON sr.submission_id = s.id
+WHERE s.contest_id = sqlc.arg('contest_id')
+  AND s.user_id = sqlc.arg('user_id')
+  AND s.problem_id = sqlc.arg('problem_id')
+  AND s.status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'output_limit', 'system_error', 'canceled')
+ORDER BY s.submitted_at, s.id;
+
 -- name: CreateRejudgeBatch :one
 INSERT INTO rejudge_batches (
     problem_id,

--- a/internal/submission/contest_projection_test.go
+++ b/internal/submission/contest_projection_test.go
@@ -1,0 +1,71 @@
+package submission
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildContestProblemProjectionUsesSubmissionOrder(t *testing.T) {
+	start := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	projection := buildContestProblemProjection(start, []contestProjectionSubmission{
+		{ID: 2, Status: StatusAccepted, SubmittedAt: start.Add(20 * time.Minute), AttemptID: int64Ptr(22)},
+		{ID: 1, Status: StatusWrongAnswer, SubmittedAt: start.Add(10 * time.Minute), AttemptID: int64Ptr(11)},
+	})
+
+	if projection.Status != StatusAccepted {
+		t.Fatalf("status = %q, want %q", projection.Status, StatusAccepted)
+	}
+	if projection.Attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", projection.Attempts)
+	}
+	if projection.PenaltyMinutes != 40 {
+		t.Fatalf("penalty minutes = %d, want 40", projection.PenaltyMinutes)
+	}
+	if projection.LastSubmissionID == nil || *projection.LastSubmissionID != 2 {
+		t.Fatalf("last submission id = %v, want 2", projection.LastSubmissionID)
+	}
+	if projection.BestSubmissionID == nil || *projection.BestSubmissionID != 2 {
+		t.Fatalf("best submission id = %v, want 2", projection.BestSubmissionID)
+	}
+	if projection.LastAttemptID == nil || *projection.LastAttemptID != 22 {
+		t.Fatalf("last attempt id = %v, want 22", projection.LastAttemptID)
+	}
+}
+
+func TestBuildContestProblemProjectionUsesCurrentRejudgeVerdict(t *testing.T) {
+	start := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	projection := buildContestProblemProjection(start, []contestProjectionSubmission{
+		{ID: 1, Status: StatusWrongAnswer, SubmittedAt: start.Add(10 * time.Minute), AttemptID: int64Ptr(102)},
+	})
+
+	if projection.Status != "attempted" {
+		t.Fatalf("status = %q, want attempted", projection.Status)
+	}
+	if projection.Attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", projection.Attempts)
+	}
+	if projection.AcceptedAt != nil || projection.BestSubmissionID != nil || projection.BestAttemptID != nil {
+		t.Fatalf("rejudged wrong answer retained accepted projection: %+v", projection)
+	}
+	if projection.LastAttemptID == nil || *projection.LastAttemptID != 102 {
+		t.Fatalf("last attempt id = %v, want 102", projection.LastAttemptID)
+	}
+}
+
+func TestBuildContestProblemProjectionUsesEarliestCurrentAcceptance(t *testing.T) {
+	start := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	projection := buildContestProblemProjection(start, []contestProjectionSubmission{
+		{ID: 2, Status: StatusWrongAnswer, SubmittedAt: start.Add(20 * time.Minute), AttemptID: int64Ptr(22)},
+		{ID: 1, Status: StatusAccepted, SubmittedAt: start.Add(10 * time.Minute), AttemptID: int64Ptr(101)},
+	})
+
+	if projection.Status != StatusAccepted || projection.Attempts != 1 || projection.PenaltyMinutes != 10 {
+		t.Fatalf("projection = %+v, want first submission accepted with 10 minute penalty", projection)
+	}
+	if projection.BestSubmissionID == nil || *projection.BestSubmissionID != 1 {
+		t.Fatalf("best submission id = %v, want 1", projection.BestSubmissionID)
+	}
+	if projection.BestAttemptID == nil || *projection.BestAttemptID != 101 {
+		t.Fatalf("best attempt id = %v, want rejudge attempt 101", projection.BestAttemptID)
+	}
+}

--- a/internal/submission/repository.go
+++ b/internal/submission/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -493,6 +494,18 @@ func (r *SQLRepository) CompleteSubmissionWithResult(ctx context.Context, id int
 	var record SubmissionRecord
 	err := postgres.WithTx(ctx, r.txRunner, func(tx pgx.Tx) error {
 		q := r.q.WithTx(tx)
+		current, err := q.GetSubmissionByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		record = submissionRecord(current)
+		if terminalStatus(record.Status) {
+			return nil
+		}
+		projectionLock, err := lockContestProblemProjection(ctx, q, record)
+		if err != nil {
+			return err
+		}
 		row, err := q.UpdateSubmissionStatus(ctx, params)
 		if errors.Is(err, pgx.ErrNoRows) {
 			row, err = q.GetSubmissionByID(ctx, id)
@@ -503,11 +516,10 @@ func (r *SQLRepository) CompleteSubmissionWithResult(ctx context.Context, id int
 		if err != nil {
 			return err
 		}
-		attempt, err := persistJudgeResult(ctx, q, record, result, score)
-		if err != nil {
+		if _, err := persistJudgeResult(ctx, q, record, result, score); err != nil {
 			return err
 		}
-		return updateContestProblemResult(ctx, q, record, attempt.ID)
+		return rebuildContestProblemResult(ctx, q, record, projectionLock)
 	})
 	return record, err
 }
@@ -634,6 +646,10 @@ func (r *SQLRepository) CompleteJudgeAttemptResult(ctx context.Context, input Co
 		if !attempt.SubmissionID.Valid {
 			return fmt.Errorf("judge attempt %d is not linked to a submission", attempt.ID)
 		}
+		projectionLock, err := lockContestProblemProjection(ctx, q, record)
+		if err != nil {
+			return err
+		}
 
 		params := db.UpdateSubmissionStatusParams{
 			Status:       status,
@@ -729,7 +745,7 @@ func (r *SQLRepository) CompleteJudgeAttemptResult(ctx context.Context, input Co
 		if err != nil {
 			return err
 		}
-		if err := updateContestProblemResult(ctx, q, record, finished.ID); err != nil {
+		if err := rebuildContestProblemResult(ctx, q, record, projectionLock); err != nil {
 			return err
 		}
 		if finished.TaskID.Valid {
@@ -953,82 +969,139 @@ func truncateSummary(value string) string {
 	return value[:limit]
 }
 
-func updateContestProblemResult(ctx context.Context, q *db.Queries, submission SubmissionRecord, attemptID int64) error {
+type contestProblemProjectionLock struct {
+	contestStart time.Time
+	enabled      bool
+}
+
+type contestProjectionSubmission struct {
+	ID          int64
+	Status      string
+	SubmittedAt time.Time
+	AttemptID   *int64
+}
+
+type contestProblemProjection struct {
+	Status           string
+	Attempts         int32
+	AcceptedAt       *time.Time
+	PenaltyMinutes   int32
+	LastSubmissionID *int64
+	BestSubmissionID *int64
+	BestAttemptID    *int64
+	LastAttemptID    *int64
+}
+
+func lockContestProblemProjection(ctx context.Context, q *db.Queries, submission SubmissionRecord) (contestProblemProjectionLock, error) {
 	if submission.ContestID == nil {
-		return nil
+		return contestProblemProjectionLock{}, nil
 	}
 	contest, err := q.GetContestByID(ctx, *submission.ContestID)
 	if err != nil {
-		return err
+		return contestProblemProjectionLock{}, err
 	}
 	problems, err := q.ListContestProblems(ctx, *submission.ContestID)
 	if err != nil {
-		return err
+		return contestProblemProjectionLock{}, err
 	}
-	inContest := false
 	for _, problem := range problems {
-		if problem.ProblemID == submission.ProblemID {
-			inContest = true
-			break
+		if problem.ProblemID != submission.ProblemID {
+			continue
 		}
+		params := db.EnsureContestProblemResultProjectionParams{
+			ContestID: *submission.ContestID,
+			UserID:    submission.UserID,
+			ProblemID: submission.ProblemID,
+		}
+		if err := q.EnsureContestProblemResultProjection(ctx, params); err != nil {
+			return contestProblemProjectionLock{}, err
+		}
+		if _, err := q.LockContestProblemResultProjection(ctx, db.LockContestProblemResultProjectionParams(params)); err != nil {
+			return contestProblemProjectionLock{}, err
+		}
+		return contestProblemProjectionLock{contestStart: contest.StartAt.Time, enabled: true}, nil
 	}
-	if !inContest {
+	return contestProblemProjectionLock{}, nil
+}
+
+func rebuildContestProblemResult(ctx context.Context, q *db.Queries, submission SubmissionRecord, lock contestProblemProjectionLock) error {
+	if !lock.enabled || submission.ContestID == nil {
 		return nil
 	}
-
-	current := db.ContestProblemResult{
-		ContestID: *submission.ContestID,
+	rows, err := q.ListContestProblemSubmissionsForProjection(ctx, db.ListContestProblemSubmissionsForProjectionParams{
+		ContestID: pgtype.Int8{Int64: *submission.ContestID, Valid: true},
 		UserID:    submission.UserID,
 		ProblemID: submission.ProblemID,
-		Status:    "none",
-	}
-	results, err := q.ListContestProblemResults(ctx, *submission.ContestID)
+	})
 	if err != nil {
 		return err
 	}
-	for _, result := range results {
-		if result.UserID == submission.UserID && result.ProblemID == submission.ProblemID {
-			current = result
-			break
-		}
+	items := make([]contestProjectionSubmission, 0, len(rows))
+	for _, row := range rows {
+		items = append(items, contestProjectionSubmission{
+			ID:          row.ID,
+			Status:      row.Status,
+			SubmittedAt: row.SubmittedAt.Time,
+			AttemptID:   int8Value(row.AttemptID),
+		})
 	}
-	if current.LastSubmissionID.Valid && current.LastSubmissionID.Int64 == submission.ID {
-		return nil
-	}
-	if current.Status == StatusAccepted {
-		return nil
-	}
-
-	attempts := current.Attempts + 1
-	status := "attempted"
+	projection := buildContestProblemProjection(lock.contestStart, items)
 	acceptedAt := pgtype.Timestamptz{}
-	penaltyMinutes := current.PenaltyMinutes
-	if submission.Status == StatusAccepted {
-		status = "accepted"
-		accepted := submission.SubmittedAt
-		acceptedAt = timestamptz(accepted)
-		penaltyMinutes = int32(accepted.Sub(contest.StartAt.Time).Minutes()) + (attempts-1)*20
-	}
-	bestSubmissionID := current.BestSubmissionID
-	bestAttemptID := current.BestAttemptID
-	if submission.Status == StatusAccepted {
-		bestSubmissionID = pgtype.Int8{Int64: submission.ID, Valid: true}
-		bestAttemptID = pgtype.Int8{Int64: attemptID, Valid: true}
+	if projection.AcceptedAt != nil {
+		acceptedAt = timestamptz(*projection.AcceptedAt)
 	}
 	_, err = q.UpsertContestProblemResult(ctx, db.UpsertContestProblemResultParams{
 		ContestID:        *submission.ContestID,
 		UserID:           submission.UserID,
 		ProblemID:        submission.ProblemID,
-		Status:           status,
-		Attempts:         attempts,
+		Status:           projection.Status,
+		Attempts:         projection.Attempts,
 		AcceptedAt:       acceptedAt,
-		PenaltyMinutes:   penaltyMinutes,
-		LastSubmissionID: pgtype.Int8{Int64: submission.ID, Valid: true},
-		BestSubmissionID: bestSubmissionID,
-		BestAttemptID:    bestAttemptID,
-		LastAttemptID:    pgtype.Int8{Int64: attemptID, Valid: true},
+		PenaltyMinutes:   projection.PenaltyMinutes,
+		LastSubmissionID: int8Ptr(projection.LastSubmissionID),
+		BestSubmissionID: int8Ptr(projection.BestSubmissionID),
+		BestAttemptID:    int8Ptr(projection.BestAttemptID),
+		LastAttemptID:    int8Ptr(projection.LastAttemptID),
 	})
 	return err
+}
+
+func buildContestProblemProjection(contestStart time.Time, submissions []contestProjectionSubmission) contestProblemProjection {
+	ordered := append([]contestProjectionSubmission(nil), submissions...)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].SubmittedAt.Equal(ordered[j].SubmittedAt) {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return ordered[i].SubmittedAt.Before(ordered[j].SubmittedAt)
+	})
+
+	projection := contestProblemProjection{Status: "none"}
+	for _, submission := range ordered {
+		projection.Status = "attempted"
+		projection.Attempts++
+		lastSubmissionID := submission.ID
+		projection.LastSubmissionID = &lastSubmissionID
+		projection.LastAttemptID = copyInt64Ptr(submission.AttemptID)
+		if submission.Status != StatusAccepted {
+			continue
+		}
+		acceptedAt := submission.SubmittedAt
+		projection.Status = StatusAccepted
+		projection.AcceptedAt = &acceptedAt
+		projection.PenaltyMinutes = int32(acceptedAt.Sub(contestStart).Minutes()) + (projection.Attempts-1)*20
+		projection.BestSubmissionID = &lastSubmissionID
+		projection.BestAttemptID = copyInt64Ptr(submission.AttemptID)
+		break
+	}
+	return projection
+}
+
+func copyInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	result := *value
+	return &result
 }
 
 func (r *SQLRepository) GetLatestJudgeAttemptBySubmissionID(ctx context.Context, submissionID int64) (JudgeAttemptRecord, error) {


### PR DESCRIPTION
## 问题

比赛成绩投影此前按判题完成顺序增量更新。异步结果乱序到达时会漏算错误尝试和罚时；重判替换 verdict 时，已有的 accepted 投影也可能因短路逻辑而无法清除。

## 修复

- 每次比赛提交进入终态后，按 `submitted_at, id` 从该用户/题目的当前终态 submissions 重算投影，不再依赖判题完成顺序。
- 从 `submission_results.attempt_id` 读取当前判题 attempt，使重判后的 verdict、best/last attempt 能替换旧结果。
- 在更新 submission 前确保并锁定对应 `contest_problem_results` 行，串行化同一用户/题目的并发完成事务，避免部分视图覆盖完整结果。
- 增加乱序完成、AC 重判为 WA、历史 WA 重判为 AC，以及 SQL 锁与当前结果关联的回归测试。

## 验证

- `go test -race ./internal/submission -run 'TestBuildContestProblemProjection'`
- `go test -race ./internal/postgres/db`
- `go test ./...`
- `go vet ./...`
- `gofmt -d internal cmd`
- `git diff --check`
- 两套 Docker Compose 配置校验

预审脚本仍报告主分支已有的 15 条 lint（12 个 errcheck、2 个 staticcheck、1 个 unused），本次改动未新增告警。

## 进展记录

- 2026-07-13：完成 TDD 回归测试、投影重算和并发锁实现，已通过本地验证。

Closes #28
