### PR TITLE
fix(contest): rebuild frozen scores by submission order

### DIFF
--- a/docs/superpowers/cases/2026-07-13-frozen-scoreboard-submission-order-bug-repro.md
+++ b/docs/superpowers/cases/2026-07-13-frozen-scoreboard-submission-order-bug-repro.md
@@ -1,0 +1,38 @@
+# Frozen Scoreboard Submission Order Bug Reproduction
+
+Issue: #29
+
+## Bug Statement
+
+The frozen scoreboard rebuild omits `output_limit` submissions and processes terminal submissions by judge completion time instead of ACM submission order. A wrong submission made before an accepted submission can therefore disappear from attempts and penalty calculations.
+
+## Minimal Cases
+
+### Reversed judge completion order
+
+- Input: submission 1 is wrong at minute 10 and judged at minute 25; submission 2 is accepted at minute 20 and judged at minute 21.
+- Before fix: the accepted submission is processed first, producing 0 wrong attempts and 20 penalty minutes.
+- After fix: submissions are processed by `submitted_at, id`, producing 1 wrong attempt and 40 penalty minutes.
+
+### Equal submission timestamps
+
+- Input: submission 1 is wrong and submission 2 is accepted at minute 20; submission 2 finishes judging first.
+- Before fix: judge completion order produces 0 wrong attempts and 20 penalty minutes.
+- After fix: ID breaks the timestamp tie, producing 1 wrong attempt and 40 penalty minutes.
+
+### Output limit terminal status
+
+- Input: an `output_limit` submission at minute 10 followed by an accepted submission at minute 20.
+- Before fix: `ListContestTerminalSubmissions` excludes the first submission, producing 0 wrong attempts and 20 penalty minutes in a database-backed rebuild.
+- After fix: the query returns `output_limit`, producing 1 wrong attempt and 40 penalty minutes.
+
+## Local Executors
+
+- `go test ./internal/contest -run TestBuildBoardFromSubmissionsUsesACMSubmissionOrder`
+- `go test ./internal/postgres/db -run TestListContestTerminalSubmissionsUsesCompleteStatusesAndSubmissionOrder`
+
+Both executors are deterministic and require no database, network, or external service.
+
+## Handoff
+
+Change frozen scoreboard sorting to `submitted_at, id`, keep `judged_at` only for freeze visibility, and synchronize the source SQL with its generated Go query. Re-run both executors to prove pass-after-fix.

--- a/internal/contest/scoreboard.go
+++ b/internal/contest/scoreboard.go
@@ -221,10 +221,10 @@ func buildBoardFromSubmissions(
 	now time.Time,
 ) ScoreboardResponse {
 	sort.Slice(submissions, func(i, j int) bool {
-		if submissions[i].JudgedAt.Equal(submissions[j].JudgedAt) {
+		if submissions[i].SubmittedAt.Equal(submissions[j].SubmittedAt) {
 			return submissions[i].ID < submissions[j].ID
 		}
-		return submissions[i].JudgedAt.Before(submissions[j].JudgedAt)
+		return submissions[i].SubmittedAt.Before(submissions[j].SubmittedAt)
 	})
 	states := make(map[int64]map[int64]*submissionCellState)
 	for _, sub := range submissions {

--- a/internal/contest/scoreboard_submission_order_test.go
+++ b/internal/contest/scoreboard_submission_order_test.go
@@ -1,0 +1,69 @@
+package contest
+
+import (
+	"testing"
+	"time"
+
+	"SOJ/internal/submission"
+)
+
+func TestBuildBoardFromSubmissionsUsesACMSubmissionOrder(t *testing.T) {
+	start := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	contest := ContestRecord{
+		ID:       1,
+		StartAt:  start,
+		FreezeAt: start.Add(time.Hour),
+	}
+	problems := []ContestProblem{{ContestID: 1, ProblemID: 101, Alias: "A", SortOrder: 1}}
+	registrations := []ContestRegistration{{
+		ID:          1,
+		ContestID:   1,
+		UserID:      20,
+		DisplayName: "alice",
+		Status:      RegistrationActive,
+	}}
+
+	tests := []struct {
+		name        string
+		submissions []ContestSubmissionResult
+		wantPenalty int32
+	}{
+		{
+			name: "submission order wins over judge completion order",
+			submissions: []ContestSubmissionResult{
+				{ID: 2, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusAccepted, SubmittedAt: start.Add(20 * time.Minute), JudgedAt: start.Add(21 * time.Minute)},
+				{ID: 1, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusWrongAnswer, SubmittedAt: start.Add(10 * time.Minute), JudgedAt: start.Add(25 * time.Minute)},
+			},
+			wantPenalty: 40,
+		},
+		{
+			name: "submission id breaks equal submitted time ties",
+			submissions: []ContestSubmissionResult{
+				{ID: 2, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusAccepted, SubmittedAt: start.Add(20 * time.Minute), JudgedAt: start.Add(21 * time.Minute)},
+				{ID: 1, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusWrongAnswer, SubmittedAt: start.Add(20 * time.Minute), JudgedAt: start.Add(25 * time.Minute)},
+			},
+			wantPenalty: 40,
+		},
+		{
+			name: "output limit counts as a wrong attempt",
+			submissions: []ContestSubmissionResult{
+				{ID: 1, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusOutputLimit, SubmittedAt: start.Add(10 * time.Minute), JudgedAt: start.Add(11 * time.Minute)},
+				{ID: 2, ContestID: 1, UserID: 20, ProblemID: 101, Status: submission.StatusAccepted, SubmittedAt: start.Add(20 * time.Minute), JudgedAt: start.Add(21 * time.Minute)},
+			},
+			wantPenalty: 40,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			board := buildBoardFromSubmissions(contest, ScoreboardViewFrozen, problems, registrations, tt.submissions, contest.FreezeAt)
+			cell := board.Rows[0].Cells[0]
+			if cell.Status != CellAccepted || cell.Attempts != 1 || cell.PenaltyMinutes != tt.wantPenalty {
+				t.Fatalf("cell = %+v, want accepted with 1 wrong attempt and %d penalty minutes", cell, tt.wantPenalty)
+			}
+			if cell.LastSubmissionID == nil || *cell.LastSubmissionID != 2 {
+				t.Fatalf("last submission id = %v, want 2", cell.LastSubmissionID)
+			}
+		})
+	}
+}

--- a/internal/postgres/db/contests.sql.go
+++ b/internal/postgres/db/contests.sql.go
@@ -615,8 +615,8 @@ SELECT id, user_id, problem_id, contest_id, status, submitted_at, judged_at
 FROM submissions
 WHERE contest_id = $1::bigint
   AND judged_at IS NOT NULL
-  AND status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'system_error', 'canceled')
-ORDER BY judged_at, id
+  AND status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'output_limit', 'system_error', 'canceled')
+ORDER BY submitted_at, id
 `
 
 type ListContestTerminalSubmissionsRow struct {

--- a/internal/postgres/db/contests_sql_test.go
+++ b/internal/postgres/db/contests_sql_test.go
@@ -1,0 +1,17 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestListContestTerminalSubmissionsUsesCompleteStatusesAndSubmissionOrder(t *testing.T) {
+	for _, want := range []string{
+		"'output_limit'",
+		"ORDER BY submitted_at, id",
+	} {
+		if !strings.Contains(listContestTerminalSubmissions, want) {
+			t.Fatalf("ListContestTerminalSubmissions missing %q:\n%s", want, listContestTerminalSubmissions)
+		}
+	}
+}

--- a/internal/postgres/queries/contests.sql
+++ b/internal/postgres/queries/contests.sql
@@ -189,8 +189,8 @@ SELECT id, user_id, problem_id, contest_id, status, submitted_at, judged_at
 FROM submissions
 WHERE contest_id = $1::bigint
   AND judged_at IS NOT NULL
-  AND status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'system_error', 'canceled')
-ORDER BY judged_at, id;
+  AND status IN ('accepted', 'wrong_answer', 'compile_error', 'runtime_error', 'time_limit', 'memory_limit', 'output_limit', 'system_error', 'canceled')
+ORDER BY submitted_at, id;
 
 -- name: ListContestScoreSnapshotCandidates :many
 SELECT id,


### PR DESCRIPTION
修复冻结榜因终态提交缺失和判题乱序导致的 ACM 尝试数、罚时与排名偏差。

## 修改内容

- `ListContestTerminalSubmissions` 补充 `output_limit`，并按 `submitted_at, id` 返回。
- 冻结榜重建按提交时间与 ID 处理，`judged_at` 仅用于冻结窗口可见性判断。
- 增加判题完成顺序相反、相同提交时间按 ID 排序、`output_limit` 计入错误尝试的回归测试与最小复现文档。

## TDD 证明

- 修复前：目标测试分别复现 0 次错误 / 20 分钟罚时，以及 SQL 缺少 `output_limit`。
- 修复后：目标测试均通过，结果为 1 次错误 / 40 分钟罚时。

## 验证

- `go test ./...`
- `go vet ./...`
- `docker compose -f deploy/docker-compose.yaml config`
- `COMPOSE_FILE=deploy/docker-compose.yaml:deploy/docker-compose.docker-runner.yaml docker compose config`
- 受影响包 `golangci-lint`：0 issues

Closes #29
