### PR TITLE
fix(problem): bound testcase archive resources

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -357,6 +357,7 @@ paths:
         "403": { $ref: "#/components/responses/PermissionDenied" }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { $ref: "#/components/responses/Conflict" }
+        "413": { $ref: "#/components/responses/PayloadTooLarge" }
         "422": { $ref: "#/components/responses/ValidationFailed" }
         "500": { $ref: "#/components/responses/InternalError" }
   /api/v1/problems/{id}/checks:
@@ -1042,6 +1043,10 @@ components:
     ValidationFailed:
       x-owner: WP1 Data/API Contract
       description: Validation failed.
+      content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
+    PayloadTooLarge:
+      x-owner: WP1 Data/API Contract
+      description: Request payload exceeds the supported size limit.
       content: { application/json: { schema: { $ref: "#/components/schemas/ErrorEnvelope" } } }
     ServiceUnavailable:
       x-owner: WP1 Data/API Contract

--- a/docs/superpowers/cases/2026-07-14-testcase-archive-resource-limits-bug-repro.md
+++ b/docs/superpowers/cases/2026-07-14-testcase-archive-resource-limits-bug-repro.md
@@ -1,0 +1,37 @@
+# Testcase Archive Resource Limits Bug Reproduction
+
+Issue: #30
+
+## Bug Statement
+
+Testcase ZIP uploads are bounded only after multipart parsing and full archive reads. ZIP entries have no shared file-count, per-entry, total-uncompressed-size, or compression-ratio budget across upload validation, problem checks, and worker parsing.
+
+## Minimal Cases
+
+### Oversized multipart request
+
+- Input: a testcase upload whose declared request size exceeds the upload request budget.
+- Before fix: multipart parsing starts and the handler returns the generic missing-archive validation error.
+- After fix: the handler rejects the request before multipart parsing with HTTP 413 and `testcase.archive_too_large`.
+
+### ZIP resource budgets
+
+- Input: archives exceeding compressed bytes, file count, single-entry bytes, total uncompressed bytes, or compression ratio.
+- Before fix: the shared resource validator accepts every case.
+- After fix: each archive returns its stable `testcase.*_exceeded` error before unbounded decompression.
+
+### Problem check and worker paths
+
+- Input: a highly compressed valid-looking testcase pair, or an entry larger than the per-entry budget.
+- Before fix: problem check reports the archive valid and worker parsing reads the full entry.
+- After fix: problem check records a publish-blocking resource finding and worker parsing returns the same bounded resource error.
+
+## Local Executors
+
+- `go test ./internal/problem -run 'TestValidateTestcaseArchiveResources|TestValidateTestcaseArchiveRejectsHighCompressionRatio|TestParseTestcaseArchiveCasesRejectsOversizedEntry|TestUploadTestcasesRejectsOversizedContentLength|TestRunProblemCheckReportsArchiveFindings'`
+
+The cases are deterministic and require no database, object store, or network service.
+
+## Handoff
+
+Implement one ZIP resource validator, bounded request/archive readers, and consistent error mapping in upload, problem check, and worker parsing paths. Preserve existing structural validation and testcase ordering behavior.

--- a/docs/v2-api-guide.md
+++ b/docs/v2-api-guide.md
@@ -84,6 +84,7 @@ Use `GET /api/v1/problems?mine=true` with an authenticated request to list only 
 
 Problem checks:
 
+- Testcase archive uploads allow at most 128 MiB of compressed ZIP data in a 129 MiB multipart request. Upload validation, problem checks, and worker parsing share limits of 16 MiB per file, 128 MiB total uncompressed data, 2048 files, and a 200:1 per-file compression ratio.
 - `POST /api/v1/problems/{id}/checks` synchronously validates the current ready testcase set for the problem. The response is a `201` envelope whose `data` is a `ProblemCheckRun`.
 - `GET /api/v1/problems/{id}/checks/{check_id}` returns the persisted check run and its findings in a `200` envelope.
 - Check endpoints are owner/admin/root scoped. They use the same error envelope as the rest of the API.

--- a/internal/problem/handler.go
+++ b/internal/problem/handler.go
@@ -2,7 +2,9 @@ package problem
 
 import (
 	"context"
+	"errors"
 	"io"
+	"net/http"
 	"strconv"
 
 	"SOJ/internal/apperror"
@@ -204,19 +206,41 @@ func (h *Handler) assignTags(c *gin.Context) {
 }
 
 func (h *Handler) uploadTestcases(c *gin.Context) {
+	h.uploadTestcasesWithRequestLimit(c, defaultMaxTestcaseUploadRequestBytes)
+}
+
+func (h *Handler) uploadTestcasesWithRequestLimit(c *gin.Context, maxRequestBytes int64) {
 	id, ok := problemIDParam(c)
 	if !ok {
 		return
 	}
+	if c.Request.ContentLength > maxRequestBytes {
+		httpapi.Error(c, testcaseUploadTooLarge())
+		return
+	}
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxRequestBytes)
 	file, header, err := c.Request.FormFile("archive")
 	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			httpapi.Error(c, testcaseUploadTooLarge())
+			return
+		}
 		httpapi.Error(c, testcaseNotReady("archive file is required"))
 		return
 	}
-	defer file.Close()
-	content, err := io.ReadAll(file)
+	defer func() { _ = file.Close() }()
+	if header.Size > defaultMaxTestcaseArchiveBytes {
+		httpapi.Error(c, testcaseUploadTooLarge())
+		return
+	}
+	content, err := io.ReadAll(io.LimitReader(file, defaultMaxTestcaseArchiveBytes+1))
 	if err != nil {
 		httpapi.Error(c, apperror.BadRequest("testcase.archive_read_failed", "failed to read archive"))
+		return
+	}
+	if len(content) > defaultMaxTestcaseArchiveBytes {
+		httpapi.Error(c, testcaseUploadTooLarge())
 		return
 	}
 	caseCount64, err := strconv.ParseInt(c.PostForm("case_count"), 10, 32)
@@ -239,6 +263,10 @@ func (h *Handler) uploadTestcases(c *gin.Context) {
 		return
 	}
 	httpapi.Created(c, set)
+}
+
+func testcaseUploadTooLarge() error {
+	return apperror.New("testcase.archive_too_large", "testcase archive is too large", http.StatusRequestEntityTooLarge)
 }
 
 func (h *Handler) runProblemCheck(c *gin.Context) {

--- a/internal/problem/handler_test.go
+++ b/internal/problem/handler_test.go
@@ -1,8 +1,10 @@
 package problem
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +13,8 @@ import (
 
 	"SOJ/internal/auth"
 	"SOJ/internal/httpapi"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestRunProblemCheckReturnsCreatedEnvelope(t *testing.T) {
@@ -163,6 +167,66 @@ func TestUploadTestcasesMissingArchiveReturnsTestcaseNotReady(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), `"code":"problem.testcase_not_ready"`) {
 		t.Fatalf("body missing problem.testcase_not_ready: %s", rec.Body.String())
+	}
+}
+
+func TestUploadTestcasesRejectsOversizedContentLengthBeforeMultipartParsing(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
+	service := NewService(repo, &fakeStorage{})
+	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/problems/1/testcase-sets", strings.NewReader("archive=x"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	req.Header.Set("X-User-ID", "10")
+	req.ContentLength = defaultMaxTestcaseUploadRequestBytes + 1
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"testcase.archive_too_large"`) {
+		t.Fatalf("body missing testcase.archive_too_large: %s", rec.Body.String())
+	}
+}
+
+func TestUploadTestcasesRejectsOversizedMultipartWithUnknownContentLength(t *testing.T) {
+	repo := newFakeRepository()
+	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
+	handler := NewHandler(NewService(repo, &fakeStorage{}))
+	router := httpapi.NewRouter(httpapi.RouterOptions{})
+	router.POST("/problems/:id/testcase-upload", func(c *gin.Context) {
+		handler.uploadTestcasesWithRequestLimit(c, 128)
+	})
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	archive, err := writer.CreateFormFile("archive", "cases.zip")
+	if err != nil {
+		t.Fatalf("create archive part: %v", err)
+	}
+	if _, err := archive.Write(bytes.Repeat([]byte("x"), 256)); err != nil {
+		t.Fatalf("write archive part: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart body: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/problems/1/testcase-upload", bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-User-ID", "10")
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"code":"testcase.archive_too_large"`) {
+		t.Fatalf("body missing testcase.archive_too_large: %s", rec.Body.String())
 	}
 }
 

--- a/internal/problem/service.go
+++ b/internal/problem/service.go
@@ -608,15 +608,24 @@ func (s *Service) RunProblemCheck(ctx context.Context, actor auth.Actor, problem
 			})
 		} else {
 			storageReadable = true
-			data, err := readAllAndClose(body)
+			data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
 			if err != nil {
-				storageReadable = false
-				findings = append(findings, problemCheckFindingDraft{
-					severity: ProblemCheckSeverityError,
-					code:     "testcase.storage_unreadable",
-					message:  "testcase archive cannot be read from storage",
-					details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
-				})
+				if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
+					findings = append(findings, problemCheckFindingDraft{
+						severity: ProblemCheckSeverityError,
+						code:     resourceErr.code,
+						message:  resourceErr.message,
+						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+					})
+				} else {
+					storageReadable = false
+					findings = append(findings, problemCheckFindingDraft{
+						severity: ProblemCheckSeverityError,
+						code:     "testcase.storage_unreadable",
+						message:  "testcase archive cannot be read from storage",
+						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+					})
+				}
 			} else {
 				archiveResult := validateProblemCheckArchive(data, set)
 				zipReadable = archiveResult.zipReadable
@@ -747,9 +756,11 @@ func (s *Service) CurrentReadyTestcaseSet(ctx context.Context, problemID int64) 
 	if err != nil {
 		return TestcaseSet{}, err
 	}
-	defer body.Close()
-	data, err := io.ReadAll(body)
+	data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
 	if err != nil {
+		if _, ok := err.(*testcaseArchiveResourceError); ok {
+			return TestcaseSet{}, testcaseArchiveBadRequest(err)
+		}
 		return TestcaseSet{}, err
 	}
 	cases, err := parseTestcaseArchiveCases(data, time.Duration(p.TimeLimitMS)*time.Millisecond, int64(p.MemoryLimitKB))
@@ -912,6 +923,21 @@ type problemCheckArchiveValidationResult struct {
 
 func validateProblemCheckArchive(data []byte, set TestcaseSetRecord) problemCheckArchiveValidationResult {
 	result := problemCheckArchiveValidationResult{}
+	if err := verifyTestcaseArchiveContents(data, defaultTestcaseArchiveLimits); err != nil {
+		code := "testcase.zip_invalid"
+		message := "testcase archive must be a valid zip file"
+		if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
+			code = resourceErr.code
+			message = resourceErr.message
+		}
+		result.findings = append(result.findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     code,
+			message:  message,
+			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+		})
+		return result
+	}
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		result.findings = append(result.findings, problemCheckFindingDraft{
@@ -1358,7 +1384,18 @@ func testcaseArchiveKey(problemID int64, checksum string) (string, error) {
 	return fmt.Sprintf("problems/%d/testcases/%s-%s.zip", problemID, checksum, hex.EncodeToString(random[:])), nil
 }
 
-func readAllAndClose(body io.ReadCloser) ([]byte, error) {
-	defer body.Close()
-	return io.ReadAll(body)
+func readAllAndClose(body io.ReadCloser, maxBytes int64) ([]byte, error) {
+	defer func() { _ = body.Close() }()
+	reader := io.Reader(body)
+	if maxBytes > 0 {
+		reader = io.LimitReader(body, maxBytes+1)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		return nil, testcaseArchiveLimitError("testcase.archive_too_large", "testcase archive is too large")
+	}
+	return data, nil
 }

--- a/internal/problem/service_test.go
+++ b/internal/problem/service_test.go
@@ -537,6 +537,15 @@ func TestRunProblemCheckReportsArchiveFindings(t *testing.T) {
 			caseCount: 2,
 			wantCodes: []string{"testcase.output_missing", "testcase.input_missing", "testcase.case_count_mismatch"},
 		},
+		{
+			name: "high compression ratio",
+			archive: zipArchive(t, map[string]string{
+				"input1.txt":  strings.Repeat("a", 1<<20),
+				"output1.txt": "1\n",
+			}),
+			caseCount: 1,
+			wantCodes: []string{"testcase.compression_ratio_exceeded"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/problem/testcase.go
+++ b/internal/problem/testcase.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"path"
 	"regexp"
 	"sort"
@@ -16,7 +17,114 @@ import (
 
 var caseNameRE = regexp.MustCompile(`^(?:input|output)([0-9]+)\.(?:txt|in|out)$`)
 
-const defaultMaxTestcaseArchiveBytes = 128 << 20
+const (
+	defaultMaxTestcaseArchiveBytes       = 128 << 20
+	defaultMaxTestcaseUploadRequestBytes = defaultMaxTestcaseArchiveBytes + (1 << 20)
+	defaultMaxTestcaseEntryBytes         = 16 << 20
+	defaultMaxTestcaseTotalBytes         = 128 << 20
+	defaultMaxTestcaseFiles              = 2048
+	defaultMaxTestcaseCompressionRatio   = 200
+)
+
+type testcaseArchiveLimits struct {
+	maxArchiveBytes     int64
+	maxEntryBytes       uint64
+	maxTotalBytes       uint64
+	maxFiles            int
+	maxCompressionRatio uint64
+}
+
+var defaultTestcaseArchiveLimits = testcaseArchiveLimits{
+	maxArchiveBytes:     defaultMaxTestcaseArchiveBytes,
+	maxEntryBytes:       defaultMaxTestcaseEntryBytes,
+	maxTotalBytes:       defaultMaxTestcaseTotalBytes,
+	maxFiles:            defaultMaxTestcaseFiles,
+	maxCompressionRatio: defaultMaxTestcaseCompressionRatio,
+}
+
+type testcaseArchiveResourceError struct {
+	code    string
+	message string
+}
+
+func (e *testcaseArchiveResourceError) Error() string {
+	return e.message
+}
+
+func validateTestcaseArchiveResources(data []byte, limits testcaseArchiveLimits) error {
+	if limits.maxArchiveBytes > 0 && int64(len(data)) > limits.maxArchiveBytes {
+		return testcaseArchiveLimitError("testcase.archive_too_large", "testcase archive is too large")
+	}
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+
+	fileCount := 0
+	var totalBytes uint64
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		fileCount++
+		if limits.maxFiles > 0 && fileCount > limits.maxFiles {
+			return testcaseArchiveLimitError("testcase.file_count_exceeded", "testcase archive has too many files")
+		}
+		if limits.maxEntryBytes > 0 && file.UncompressedSize64 > limits.maxEntryBytes {
+			return testcaseArchiveLimitError("testcase.entry_too_large", "testcase archive entry is too large")
+		}
+		if limits.maxTotalBytes > 0 && (file.UncompressedSize64 > limits.maxTotalBytes || totalBytes > limits.maxTotalBytes-file.UncompressedSize64) {
+			return testcaseArchiveLimitError("testcase.total_size_exceeded", "testcase archive expands to too much data")
+		}
+		totalBytes += file.UncompressedSize64
+		if compressionRatioExceeded(file.UncompressedSize64, file.CompressedSize64, limits.maxCompressionRatio) {
+			return testcaseArchiveLimitError("testcase.compression_ratio_exceeded", "testcase archive compression ratio is too high")
+		}
+	}
+	return nil
+}
+
+func verifyTestcaseArchiveContents(data []byte, limits testcaseArchiveLimits) error {
+	if err := validateTestcaseArchiveResources(data, limits); err != nil {
+		return err
+	}
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+	var totalBytes uint64
+	for _, file := range reader.File {
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		readBytes, err := verifyZipFile(file, limits.maxEntryBytes)
+		if err != nil {
+			return err
+		}
+		if limits.maxTotalBytes > 0 && (readBytes > limits.maxTotalBytes || totalBytes > limits.maxTotalBytes-readBytes) {
+			return testcaseArchiveLimitError("testcase.total_size_exceeded", "testcase archive expands to too much data")
+		}
+		totalBytes += readBytes
+	}
+	return nil
+}
+
+func testcaseArchiveLimitError(code, message string) error {
+	return &testcaseArchiveResourceError{code: code, message: message}
+}
+
+func compressionRatioExceeded(uncompressed, compressed, maxRatio uint64) bool {
+	if maxRatio == 0 || uncompressed == 0 {
+		return false
+	}
+	if compressed == 0 {
+		return true
+	}
+	if compressed > math.MaxUint64/maxRatio {
+		return false
+	}
+	return uncompressed > compressed*maxRatio
+}
 
 func validateTestcaseArchive(data []byte, expectedCaseCount int32, expectedSHA256 string, maxSizeBytes int64) error {
 	if len(data) == 0 {
@@ -34,6 +142,11 @@ func validateTestcaseArchive(data []byte, expectedCaseCount int32, expectedSHA25
 	actualSHA256 := sha256Hex(data)
 	if !strings.EqualFold(expectedSHA256, actualSHA256) {
 		return testcaseNotReady("sha256 does not match archive content")
+	}
+	limits := defaultTestcaseArchiveLimits
+	limits.maxArchiveBytes = maxSizeBytes
+	if err := verifyTestcaseArchiveContents(data, limits); err != nil {
+		return testcaseNotReady(testcaseArchiveErrorMessage(err))
 	}
 
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
@@ -79,6 +192,9 @@ func validateTestcaseArchive(data []byte, expectedCaseCount int32, expectedSHA25
 }
 
 func parseTestcaseArchiveCases(data []byte, defaultTimeLimit time.Duration, defaultMemoryKB int64) ([]Testcase, error) {
+	if err := validateTestcaseArchiveResources(data, defaultTestcaseArchiveLimits); err != nil {
+		return nil, testcaseArchiveBadRequest(err)
+	}
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return nil, apperror.BadRequest("testcase.zip_invalid", "testcase archive must be a valid zip file")
@@ -86,6 +202,7 @@ func parseTestcaseArchiveCases(data []byte, defaultTimeLimit time.Duration, defa
 
 	inputs := map[string]string{}
 	outputs := map[string]string{}
+	var totalBytes uint64
 	for _, file := range reader.File {
 		if file.FileInfo().IsDir() {
 			continue
@@ -96,10 +213,15 @@ func parseTestcaseArchiveCases(data []byte, defaultTimeLimit time.Duration, defa
 		if len(matches) != 2 {
 			continue
 		}
-		content, err := readZipFile(file)
+		content, err := readZipFile(file, defaultTestcaseArchiveLimits.maxEntryBytes)
 		if err != nil {
 			return nil, err
 		}
+		contentBytes := uint64(len(content))
+		if contentBytes > defaultTestcaseArchiveLimits.maxTotalBytes || totalBytes > defaultTestcaseArchiveLimits.maxTotalBytes-contentBytes {
+			return nil, apperror.BadRequest("testcase.total_size_exceeded", "testcase archive expands to too much data")
+		}
+		totalBytes += contentBytes
 		if strings.HasPrefix(lower, "input") {
 			inputs[matches[1]] = content
 		} else {
@@ -142,17 +264,57 @@ func parseTestcaseArchiveCases(data []byte, defaultTimeLimit time.Duration, defa
 	return cases, nil
 }
 
-func readZipFile(file *zip.File) (string, error) {
+func readZipFile(file *zip.File, maxBytes uint64) (string, error) {
 	reader, err := file.Open()
 	if err != nil {
 		return "", fmt.Errorf("open testcase file %s: %w", file.Name, err)
 	}
-	defer reader.Close()
-	data, err := io.ReadAll(reader)
+	defer func() { _ = reader.Close() }()
+	data, err := io.ReadAll(io.LimitReader(reader, limitedReadBytes(maxBytes)))
 	if err != nil {
 		return "", fmt.Errorf("read testcase file %s: %w", file.Name, err)
 	}
+	if maxBytes > 0 && uint64(len(data)) > maxBytes {
+		return "", apperror.BadRequest("testcase.entry_too_large", "testcase archive entry is too large")
+	}
 	return string(data), nil
+}
+
+func verifyZipFile(file *zip.File, maxBytes uint64) (uint64, error) {
+	reader, err := file.Open()
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = reader.Close() }()
+	readBytes, err := io.Copy(io.Discard, io.LimitReader(reader, limitedReadBytes(maxBytes)))
+	if err != nil {
+		return 0, err
+	}
+	if maxBytes > 0 && uint64(readBytes) > maxBytes {
+		return 0, testcaseArchiveLimitError("testcase.entry_too_large", "testcase archive entry is too large")
+	}
+	return uint64(readBytes), nil
+}
+
+func limitedReadBytes(maxBytes uint64) int64 {
+	if maxBytes == 0 || maxBytes >= math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return int64(maxBytes) + 1
+}
+
+func testcaseArchiveErrorMessage(err error) string {
+	if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
+		return resourceErr.message
+	}
+	return "testcase archive must be a valid zip file"
+}
+
+func testcaseArchiveBadRequest(err error) error {
+	if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
+		return apperror.BadRequest(resourceErr.code, resourceErr.message)
+	}
+	return apperror.BadRequest("testcase.zip_invalid", "testcase archive must be a valid zip file")
 }
 
 func testcaseNotReady(message string) error {

--- a/internal/problem/testcase_limits_test.go
+++ b/internal/problem/testcase_limits_test.go
@@ -1,0 +1,136 @@
+package problem
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"SOJ/internal/apperror"
+)
+
+func TestValidateTestcaseArchiveResourcesRejectsExceededBudgets(t *testing.T) {
+	tests := []struct {
+		name    string
+		archive []byte
+		limits  testcaseArchiveLimits
+		code    string
+	}{
+		{
+			name:    "compressed archive",
+			archive: []byte("too large"),
+			limits:  testcaseArchiveLimits{maxArchiveBytes: 4},
+			code:    "testcase.archive_too_large",
+		},
+		{
+			name: "file count",
+			archive: resourceTestZip(t, zip.Store, map[string]string{
+				"input1.txt":  "1",
+				"output1.txt": "1",
+			}),
+			limits: testcaseArchiveLimits{maxFiles: 1},
+			code:   "testcase.file_count_exceeded",
+		},
+		{
+			name:    "single entry",
+			archive: resourceTestZip(t, zip.Store, map[string]string{"input1.txt": "12345"}),
+			limits:  testcaseArchiveLimits{maxEntryBytes: 4},
+			code:    "testcase.entry_too_large",
+		},
+		{
+			name: "total uncompressed bytes",
+			archive: resourceTestZip(t, zip.Store, map[string]string{
+				"input1.txt":  "12345",
+				"output1.txt": "12345",
+			}),
+			limits: testcaseArchiveLimits{maxEntryBytes: 10, maxTotalBytes: 9},
+			code:   "testcase.total_size_exceeded",
+		},
+		{
+			name:    "compression ratio",
+			archive: resourceTestZip(t, zip.Deflate, map[string]string{"input1.txt": strings.Repeat("a", 4096)}),
+			limits:  testcaseArchiveLimits{maxEntryBytes: 8192, maxTotalBytes: 8192, maxFiles: 1, maxCompressionRatio: 2},
+			code:    "testcase.compression_ratio_exceeded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTestcaseArchiveResources(tt.archive, tt.limits)
+			resourceErr, ok := err.(*testcaseArchiveResourceError)
+			if !ok || resourceErr.code != tt.code {
+				t.Fatalf("error = %T %v, want resource error %q", err, err, tt.code)
+			}
+		})
+	}
+}
+
+func TestValidateTestcaseArchiveResourcesAllowsExactBudgets(t *testing.T) {
+	archive := resourceTestZip(t, zip.Store, map[string]string{
+		"input1.txt":  "12345",
+		"output1.txt": "12345",
+	})
+	limits := testcaseArchiveLimits{
+		maxArchiveBytes:     int64(len(archive)),
+		maxEntryBytes:       5,
+		maxTotalBytes:       10,
+		maxFiles:            2,
+		maxCompressionRatio: 1,
+	}
+
+	if err := validateTestcaseArchiveResources(archive, limits); err != nil {
+		t.Fatalf("exact resource budgets returned error: %v", err)
+	}
+}
+
+func TestReadAllAndCloseRejectsOversizedArchive(t *testing.T) {
+	_, err := readAllAndClose(io.NopCloser(strings.NewReader("12345")), 4)
+	resourceErr, ok := err.(*testcaseArchiveResourceError)
+	if !ok || resourceErr.code != "testcase.archive_too_large" {
+		t.Fatalf("error = %T %v, want testcase.archive_too_large", err, err)
+	}
+}
+
+func TestValidateTestcaseArchiveRejectsHighCompressionRatio(t *testing.T) {
+	archive := zipArchive(t, map[string]string{
+		"input1.txt":  strings.Repeat("a", 1<<20),
+		"output1.txt": "1\n",
+	})
+
+	err := validateTestcaseArchive(archive, 1, sha256Hex(archive), defaultMaxTestcaseArchiveBytes)
+	assertAppCode(t, err, "problem.testcase_not_ready")
+}
+
+func TestParseTestcaseArchiveCasesRejectsOversizedEntry(t *testing.T) {
+	archive := zipArchive(t, map[string]string{
+		"input1.txt":  strings.Repeat("a", defaultMaxTestcaseEntryBytes+1),
+		"output1.txt": "1\n",
+	})
+
+	_, err := parseTestcaseArchiveCases(archive, time.Second, 1024)
+	appErr, ok := apperror.From(err)
+	if !ok || appErr.Code != "testcase.entry_too_large" {
+		t.Fatalf("error = %T %v, want testcase.entry_too_large", err, err)
+	}
+}
+
+func resourceTestZip(t *testing.T, method uint16, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for name, content := range files {
+		entry, err := writer.CreateHeader(&zip.FileHeader{Name: name, Method: method})
+		if err != nil {
+			t.Fatalf("create zip entry: %v", err)
+		}
+		if _, err := entry.Write([]byte(content)); err != nil {
+			t.Fatalf("write zip entry: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+	return buf.Bytes()
+}


### PR DESCRIPTION
## 问题

测试数据 ZIP 只在完整读取后检查压缩大小，multipart、problem check 和 worker 解压路径缺少统一资源上限。高压缩比或超大 entry 可绕过发布检查，并在 API 或 worker 中造成不受控的内存与临时磁盘消耗。

## 修复

- multipart 解析前通过 `Content-Length` 和 `http.MaxBytesReader` 限制 129 MiB 请求，archive part 使用有界读取并以 HTTP 413 返回稳定错误。
- 上传、problem check 和 worker 共用 ZIP 预算：128 MiB 压缩包、16 MiB 单文件、128 MiB 总解压、2048 文件、200:1 单文件压缩比。
- 上传与 problem check 在预算内完整解压校验；worker 逐 entry 使用 `io.LimitReader`，实际读取量再次计入总预算。
- OpenAPI 和 API 指南同步 413 响应及资源限制。

## TDD 证明

修复前用例证明：超大请求返回 422、高压缩比归档通过 problem check、worker 无限制读取超大 entry，五类预算均未生效。修复后覆盖声明长度与未知长度 multipart、压缩大小、文件数、单文件、总解压、压缩比及精确边界。

## 验证

- `go test ./...`
- `go vet ./...`
- `docker compose -f deploy/docker-compose.yaml config`
- `COMPOSE_FILE=deploy/docker-compose.yaml:deploy/docker-compose.docker-runner.yaml docker compose config`
- OpenAPI YAML 解析
- `golangci-lint run --new-from-rev=origin/main ./internal/problem`：0 issues

补充：`go test -race ./internal/problem` 会命中既有 `fakeRepository` 无锁读取；已在未修改的 `main` 上单独复现，不属于本次变更。

Closes #30
