### PR TITLE
fix(quality): resolve golangci-lint findings

### DIFF
--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func RunMigrate(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+func RunMigrate(ctx context.Context, args []string, stdout, stderr io.Writer) (err error) {
 	fs := flag.NewFlagSet("soj-migrate", flag.ContinueOnError)
 	fs.SetOutput(stdout)
 	dir := fs.String("dir", "", "migration directory")
@@ -46,7 +46,11 @@ func RunMigrate(ctx context.Context, args []string, stdout, stderr io.Writer) er
 	if err != nil {
 		return err
 	}
-	defer conn.Close(ctx)
+	defer func() {
+		if closeErr := conn.Close(ctx); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close migration database connection: %w", closeErr))
+		}
+	}()
 
 	return migrateUp(ctx, conn, cfg.Migrations.Dir, stdout)
 }

--- a/internal/postgres/tx.go
+++ b/internal/postgres/tx.go
@@ -2,6 +2,8 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -11,14 +13,18 @@ type TxRunner interface {
 	BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error)
 }
 
-func WithTx(ctx context.Context, db TxRunner, fn func(pgx.Tx) error) error {
+func WithTx(ctx context.Context, db TxRunner, fn func(pgx.Tx) error) (err error) {
 	tx, err := db.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			err = errors.Join(err, fmt.Errorf("rollback transaction: %w", rollbackErr))
+		}
+	}()
 
-	if err := fn(tx); err != nil {
+	if err = fn(tx); err != nil {
 		return err
 	}
 

--- a/internal/postgres/tx_test.go
+++ b/internal/postgres/tx_test.go
@@ -1,0 +1,70 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestWithTxJoinsRollbackFailure(t *testing.T) {
+	callbackErr := errors.New("callback failed")
+	rollbackErr := errors.New("rollback failed")
+	tx := &recordingTx{rollbackErr: rollbackErr}
+
+	err := WithTx(context.Background(), recordingTxRunner{tx: tx}, func(pgx.Tx) error {
+		return callbackErr
+	})
+
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("WithTx error = %v, want callback error %v", err, callbackErr)
+	}
+	if !errors.Is(err, rollbackErr) {
+		t.Fatalf("WithTx error = %v, want rollback error %v", err, rollbackErr)
+	}
+	if !tx.rolledBack {
+		t.Fatal("WithTx did not roll back the transaction")
+	}
+}
+
+func TestWithTxIgnoresRollbackAfterCommit(t *testing.T) {
+	tx := &recordingTx{rollbackErr: pgx.ErrTxClosed}
+
+	err := WithTx(context.Background(), recordingTxRunner{tx: tx}, func(pgx.Tx) error {
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("WithTx error = %v, want nil", err)
+	}
+	if !tx.committed || !tx.rolledBack {
+		t.Fatalf("transaction state = committed:%t rolled_back:%t, want both true", tx.committed, tx.rolledBack)
+	}
+}
+
+type recordingTxRunner struct {
+	tx pgx.Tx
+}
+
+func (r recordingTxRunner) BeginTx(context.Context, pgx.TxOptions) (pgx.Tx, error) {
+	return r.tx, nil
+}
+
+type recordingTx struct {
+	pgx.Tx
+	commitErr   error
+	rollbackErr error
+	committed   bool
+	rolledBack  bool
+}
+
+func (tx *recordingTx) Commit(context.Context) error {
+	tx.committed = true
+	return tx.commitErr
+}
+
+func (tx *recordingTx) Rollback(context.Context) error {
+	tx.rolledBack = true
+	return tx.rollbackErr
+}

--- a/internal/problem/handler.go
+++ b/internal/problem/handler.go
@@ -187,24 +187,6 @@ func (h *Handler) currentStatement(c *gin.Context) {
 	httpapi.OK(c, statement)
 }
 
-func (h *Handler) assignTags(c *gin.Context) {
-	id, ok := problemIDParam(c)
-	if !ok {
-		return
-	}
-	var req AssignTagsInput
-	if err := c.ShouldBindJSON(&req); err != nil {
-		httpapi.Error(c, apperror.BadRequest("request.invalid", "invalid request body"))
-		return
-	}
-	tags, err := h.service.AssignTags(c.Request.Context(), actorFromContext(c), id, req)
-	if err != nil {
-		httpapi.Error(c, err)
-		return
-	}
-	httpapi.OK(c, tags)
-}
-
 func (h *Handler) uploadTestcases(c *gin.Context) {
 	h.uploadTestcasesWithRequestLimit(c, defaultMaxTestcaseUploadRequestBytes)
 }

--- a/internal/problem/service.go
+++ b/internal/problem/service.go
@@ -419,7 +419,7 @@ func (s *Service) ArchiveProblem(ctx context.Context, actor auth.Actor, id int64
 }
 
 func (s *Service) CreateStatement(ctx context.Context, actor auth.Actor, problemID int64, input CreateStatementInput) (Statement, error) {
-	if input.MakeCurrent == false {
+	if !input.MakeCurrent {
 		input.MakeCurrent = true
 	}
 	if err := validateStatement(input); err != nil {

--- a/internal/submission/handler.go
+++ b/internal/submission/handler.go
@@ -284,7 +284,7 @@ func (h *Handler) UpdateLanguage(c *gin.Context) {
 		httpapi.Error(c, apperror.BadRequest("invalid_request", err.Error()))
 		return
 	}
-	item, err := h.service.UpdateLanguage(c.Request.Context(), actorFromContext(c), id, UpdateLanguageInput{Enabled: req.Enabled, DefaultTimeLimitMS: req.DefaultTimeLimitMS, DefaultMemoryLimitKB: req.DefaultMemoryLimitKB})
+	item, err := h.service.UpdateLanguage(c.Request.Context(), actorFromContext(c), id, UpdateLanguageInput(req))
 	if err != nil {
 		httpapi.Error(c, err)
 		return

--- a/internal/submission/storage.go
+++ b/internal/submission/storage.go
@@ -7,6 +7,7 @@ import (
 	crand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -61,8 +62,15 @@ func (s *ObjectSourceStore) Get(ctx context.Context, storageKey string) ([]byte,
 	if err != nil {
 		return nil, err
 	}
-	defer body.Close()
-	return io.ReadAll(body)
+	return readAllAndClose(body)
+}
+
+func readAllAndClose(reader io.ReadCloser) ([]byte, error) {
+	data, err := io.ReadAll(reader)
+	if closeErr := reader.Close(); closeErr != nil {
+		return nil, errors.Join(err, closeErr)
+	}
+	return data, err
 }
 
 type TestcaseSnapshotResolver struct {
@@ -105,8 +113,7 @@ func (r *TestcaseSnapshotResolver) testcaseSetFromRow(ctx context.Context, id, p
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
-	defer body.Close()
-	data, err := io.ReadAll(body)
+	data, err := readAllAndClose(body)
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
@@ -180,8 +187,7 @@ func readSnapshotZipFile(file *zip.File) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open testcase file %s: %w", file.Name, err)
 	}
-	defer reader.Close()
-	data, err := io.ReadAll(reader)
+	data, err := readAllAndClose(reader)
 	if err != nil {
 		return "", fmt.Errorf("read testcase file %s: %w", file.Name, err)
 	}

--- a/internal/submission/storage_test.go
+++ b/internal/submission/storage_test.go
@@ -3,9 +3,25 @@ package submission
 import (
 	"archive/zip"
 	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 	"time"
+
+	"SOJ/internal/storage"
 )
+
+func TestObjectSourceStoreGetReturnsCloseError(t *testing.T) {
+	closeErr := errors.New("close source object")
+	store := &recordingObjectStorage{body: &closeErrorReadCloser{Reader: strings.NewReader("source"), err: closeErr}}
+
+	_, err := NewObjectSourceStore(store).Get(context.Background(), "submissions/1/source")
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("Get error = %v, want close error %v", err, closeErr)
+	}
+}
 
 func TestParseSnapshotTestcaseCasesAppliesProblemLimits(t *testing.T) {
 	archive := snapshotZipArchive(t, map[string]string{
@@ -42,4 +58,33 @@ func snapshotZipArchive(t *testing.T, files map[string]string) []byte {
 		t.Fatalf("close zip: %v", err)
 	}
 	return buf.Bytes()
+}
+
+type closeErrorReadCloser struct {
+	io.Reader
+	err error
+}
+
+func (r *closeErrorReadCloser) Close() error {
+	return r.err
+}
+
+type recordingObjectStorage struct {
+	body io.ReadCloser
+}
+
+func (s *recordingObjectStorage) Put(context.Context, storage.Object) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, nil
+}
+
+func (s *recordingObjectStorage) Get(context.Context, string) (io.ReadCloser, storage.ObjectInfo, error) {
+	return s.body, storage.ObjectInfo{}, nil
+}
+
+func (s *recordingObjectStorage) Delete(context.Context, string) error {
+	return nil
+}
+
+func (s *recordingObjectStorage) Stat(context.Context, string) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, nil
 }


### PR DESCRIPTION
## Summary
- Returns object-reader close failures and preserves transaction rollback failures for diagnosis.
- Returns migration connection close failures instead of silently discarding them.
- Removes the unregistered handler and applies the two equivalent static-analysis rewrites.

## Verification
- [x] TDD: close and rollback failure tests fail before the implementation and pass afterward
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] Docker Compose configuration validation

Fixes #46

## 更新记录
- 2026-07-15：清理全部 8 项 golangci-lint 存量告警，并为关闭与回滚错误补充回归测试。