### PR TITLE
fix(postgres): scope problem stats aggregation

### DIFF
--- a/docs/superpowers/cases/2026-07-17-problem-stats-query-scope-bug-repro.md
+++ b/docs/superpowers/cases/2026-07-17-problem-stats-query-scope-bug-repro.md
@@ -1,0 +1,99 @@
+# Problem Stats Query Scope Bug Repro Cases
+
+Source:
+- GitHub issue #40
+- `internal/postgres/queries/problems.sql`
+- `internal/postgres/db/problems.sql.go`
+
+## Structured Output
+
+```yaml
+analysis:
+  bug_class: boundary
+  affected_layers:
+    - storage
+  root_cause_summary: "GetProblemStats filters the outer problem row but aggregates submission status counts for every problem before joining the requested row."
+  missing_information: []
+  reproducibility:
+    status: reproducible
+    blockers: []
+
+coverage_plan:
+  obligations:
+    - trigger_bug
+    - prove_before_fail
+    - prove_after_pass
+    - cover_boundary_class
+  selected_cases:
+    - scoped-status-aggregation
+
+cases:
+  - case_id: scoped-status-aggregation
+    purpose: trigger
+    target_layer: service
+    minimality_reason: "One query shape is sufficient to prove whether the status aggregation can scan submissions outside the requested problem."
+    input:
+      http: {}
+      service:
+        function: "db.Queries.GetProblemStats"
+        args: "problemID=42"
+      fixtures:
+        db: "generated SQL constant and source query file"
+        es: not-needed
+        redis: not-needed
+        files: "queries/problems.sql"
+        network: not-needed
+    isolation:
+      db: fixture
+      es: not-needed
+      doris: not-needed
+      redis: not-needed
+      file_io: mock
+      network: not-needed
+    before_expectation:
+      outcome: wrong-state
+      assertion: "status aggregation contains GROUP BY problem_id, status without WHERE s.problem_id = $1"
+    after_expectation:
+      outcome: pass
+      assertion: "source and generated GetProblemStats SQL contain WHERE s.problem_id = $1 and GROUP BY s.status"
+    obligations_covered:
+      - trigger_bug
+      - prove_before_fail
+      - prove_after_pass
+      - cover_boundary_class
+
+executors:
+  http_reproducer:
+    needed: false
+    strategy: none
+    target_files: []
+    setup_notes: []
+  service_reproducer:
+    needed: true
+    strategy: direct-call
+    target_files:
+      - internal/postgres/db/problems_sql_test.go
+      - internal/postgres/queries/problems.sql
+      - internal/postgres/db/problems.sql.go
+    setup_notes:
+      - "The static query test verifies the source and generated sqlc query remain synchronized."
+      - "The existing submissions_problem_status_idx supports the filtered aggregation."
+
+minimization:
+  core_case: scoped-status-aggregation
+  removed_candidates:
+    - case_id: multi-problem-explain
+      removal_reason: same-obligation
+  final_case_count: 1
+
+handoff:
+  artifact_path: docs/superpowers/cases/2026-07-17-problem-stats-query-scope-bug-repro.md
+  summary: "Push the requested problem id into the status-count aggregation and calculate all statistics from that scoped result."
+  next_goal: "Rewrite GetProblemStats so its only submissions aggregation is constrained by the requested problem id."
+  suggested_skills:
+    - go-feature-change-review
+    - pr-creator
+  verification_focus:
+    - "The source and generated SQL both scope the aggregation with problem_id = $1."
+    - "Totals, accepted count, and status JSON are derived from the scoped aggregation."
+```

--- a/internal/postgres/db/problems.sql.go
+++ b/internal/postgres/db/problems.sql.go
@@ -769,16 +769,16 @@ func (q *Queries) GetProblemCheckRunByID(ctx context.Context, id int64) (Problem
 const getProblemStats = `-- name: GetProblemStats :one
 SELECT
     p.id AS problem_id,
-    count(s.id)::bigint AS total_submissions,
-    count(s.id) FILTER (WHERE s.status = 'accepted')::bigint AS accepted_submissions,
-    coalesce(jsonb_object_agg(s.status, status_counts.count) FILTER (WHERE s.status IS NOT NULL), '{}'::jsonb) AS status_counts
+    coalesce(sum(status_counts.count), 0)::bigint AS total_submissions,
+    coalesce(sum(status_counts.count) FILTER (WHERE status_counts.status = 'accepted'), 0)::bigint AS accepted_submissions,
+    coalesce(jsonb_object_agg(status_counts.status, status_counts.count) FILTER (WHERE status_counts.status IS NOT NULL), '{}'::jsonb) AS status_counts
 FROM problems p
-LEFT JOIN submissions s ON s.problem_id = p.id
 LEFT JOIN (
-    SELECT problem_id, status, count(*)::bigint AS count
-    FROM submissions
-    GROUP BY problem_id, status
-) status_counts ON status_counts.problem_id = s.problem_id AND status_counts.status = s.status
+    SELECT s.status, count(*)::bigint AS count
+    FROM submissions s
+    WHERE s.problem_id = $1
+    GROUP BY s.status
+) status_counts ON true
 WHERE p.id = $1
 GROUP BY p.id
 `

--- a/internal/postgres/db/problems_sql_test.go
+++ b/internal/postgres/db/problems_sql_test.go
@@ -1,0 +1,55 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetProblemStatsScopesStatusAggregationToRequestedProblem(t *testing.T) {
+	source, err := os.ReadFile(filepath.Join("..", "queries", "problems.sql"))
+	if err != nil {
+		t.Fatalf("read problems queries: %v", err)
+	}
+
+	for _, test := range []struct {
+		name  string
+		query string
+	}{
+		{name: "source", query: namedQuery(t, string(source), "-- name: GetProblemStats :one")},
+		{name: "generated", query: getProblemStats},
+	} {
+		for _, want := range []string{
+			"SELECT s.status, count(*)::bigint AS count",
+			"FROM submissions s",
+			"WHERE s.problem_id = $1",
+			"GROUP BY s.status",
+			"coalesce(sum(status_counts.count), 0)::bigint AS total_submissions",
+			"coalesce(sum(status_counts.count) FILTER (WHERE status_counts.status = 'accepted'), 0)::bigint AS accepted_submissions",
+			"jsonb_object_agg(status_counts.status, status_counts.count)",
+			") status_counts ON true",
+		} {
+			if !strings.Contains(test.query, want) {
+				t.Fatalf("%s GetProblemStats missing %q:\n%s", test.name, want, test.query)
+			}
+		}
+		if strings.Contains(test.query, "GROUP BY problem_id, status") {
+			t.Fatalf("%s GetProblemStats aggregates every problem:\n%s", test.name, test.query)
+		}
+	}
+}
+
+func namedQuery(t *testing.T, source, name string) string {
+	t.Helper()
+
+	_, query, found := strings.Cut(source, name)
+	if !found {
+		t.Fatalf("query %q not found", name)
+	}
+	query, _, found = strings.Cut(query, ";")
+	if !found {
+		t.Fatalf("query %q has no terminating semicolon", name)
+	}
+	return name + query
+}

--- a/internal/postgres/queries/problems.sql
+++ b/internal/postgres/queries/problems.sql
@@ -325,15 +325,15 @@ ORDER BY id;
 -- name: GetProblemStats :one
 SELECT
     p.id AS problem_id,
-    count(s.id)::bigint AS total_submissions,
-    count(s.id) FILTER (WHERE s.status = 'accepted')::bigint AS accepted_submissions,
-    coalesce(jsonb_object_agg(s.status, status_counts.count) FILTER (WHERE s.status IS NOT NULL), '{}'::jsonb) AS status_counts
+    coalesce(sum(status_counts.count), 0)::bigint AS total_submissions,
+    coalesce(sum(status_counts.count) FILTER (WHERE status_counts.status = 'accepted'), 0)::bigint AS accepted_submissions,
+    coalesce(jsonb_object_agg(status_counts.status, status_counts.count) FILTER (WHERE status_counts.status IS NOT NULL), '{}'::jsonb) AS status_counts
 FROM problems p
-LEFT JOIN submissions s ON s.problem_id = p.id
 LEFT JOIN (
-    SELECT problem_id, status, count(*)::bigint AS count
-    FROM submissions
-    GROUP BY problem_id, status
-) status_counts ON status_counts.problem_id = s.problem_id AND status_counts.status = s.status
+    SELECT s.status, count(*)::bigint AS count
+    FROM submissions s
+    WHERE s.problem_id = $1
+    GROUP BY s.status
+) status_counts ON true
 WHERE p.id = $1
 GROUP BY p.id;


### PR DESCRIPTION
## Summary

- Scope `GetProblemStats` status aggregation to the requested `problem_id`.
- Derive total submissions, accepted submissions, and status JSON from the scoped aggregate.
- Add a TDD regression test for the source SQL and generated sqlc query, plus the reproduction record.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `make compose-config`
- `make compose-config-docker-runner`
- PostgreSQL 16 fixture: problem `42` returned `3` submissions, `2` accepted, and the expected status JSON; the plan used `submissions_problem_status_idx` with `problem_id = 42`.

## Timeline

- 2026-07-17: 复现全表状态聚合问题，补充先失败的查询范围回归测试。
- 2026-07-17: 将题目 ID 条件下推到状态聚合并完成本地 PostgreSQL 语义与执行计划验证。

Fixes #40
