### PR TITLE
refactor(problem): split workflow ports

### DIFF
--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -71,7 +71,12 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 	userRepo := user.NewPostgresRepository(queries)
 	userService := user.NewService(userRepo, jwtManager, user.WithTokenTTLs(cfg.Auth.AccessTokenTTL, cfg.Auth.RefreshTokenTTL))
 	problemRepo := problem.NewPostgresRepository(pool)
-	problemService := problem.NewService(problemRepo, objectStorage)
+	problemReader := problem.NewProblemReader(problemRepo, objectStorage)
+	problemService := problem.NewService(
+		problemReader,
+		problem.NewProblemAuthoring(problemRepo, objectStorage),
+		problem.NewProblemCheckService(problemRepo, objectStorage, time.Now),
+	)
 	contestRepo := contest.NewPostgresRepository(pool)
 	contestService := contest.NewService(contestRepo)
 	submissionRepo := submission.NewSQLRepositoryWithTxRunner(queries, pool)
@@ -80,7 +85,7 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 	sourceStore := submission.NewObjectSourceStore(objectStorage)
 	creator := submission.NewSubmissionCreator(submission.SubmissionCreatorOptions{
 		Store:            submissionRepo,
-		ProblemReader:    problemService,
+		ProblemReader:    problemReader,
 		TestcaseResolver: testcaseResolver,
 		SourceStore:      sourceStore,
 		ContestPolicy:    contestService,
@@ -88,7 +93,7 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 	reader := submission.NewSubmissionReader(submissionRepo, contestService)
 	runs := submission.NewRunService(submission.RunServiceOptions{
 		Store:         submissionRepo,
-		ProblemReader: problemService,
+		ProblemReader: problemReader,
 		SourceStore:   sourceStore,
 		Judge:         judgeEngine,
 		Context:       ctx,
@@ -98,7 +103,7 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 	languages := submission.NewLanguageService(submissionRepo, judgeEngine)
 	completer := submission.NewSubmissionCompleter(submissionRepo, contestService, nil)
 	submissionService := submission.NewService(creator, reader, runs, languages, completer)
-	rejudgeService := submission.NewRejudgeService(submissionRepo, rejudgeAuthorizationPolicy{problems: problemService, contests: contestService}, nil, metrics)
+	rejudgeService := submission.NewRejudgeService(submissionRepo, rejudgeAuthorizationPolicy{problems: problemReader, contests: contestService}, nil, metrics)
 
 	middleware := httpapi.DefaultMiddlewareSet()
 	middleware.Auth = actorMiddleware(jwtManager)
@@ -136,7 +141,7 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 }
 
 type rejudgeAuthorizationPolicy struct {
-	problems *problem.Service
+	problems *problem.ProblemReader
 	contests *contest.Service
 }
 

--- a/internal/app/worker.go
+++ b/internal/app/worker.go
@@ -71,7 +71,7 @@ func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) err
 
 	queries := db.New(pool)
 	submissionRepo := submission.NewSQLRepositoryWithTxRunner(queries, pool)
-	problemService := problem.NewService(problem.NewPostgresRepository(pool), objectStore)
+	problemReader := problem.NewProblemReader(problem.NewPostgresRepository(pool), objectStore)
 	testcaseResolver := submission.NewTestcaseSnapshotResolver(queries, objectStore)
 	taskQueue := queue.NewRedisStreamQueue(redisClient, queue.RedisStreamConfig{
 		Stream:     cfg.Redis.Stream,
@@ -108,7 +108,7 @@ func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) err
 		Failures:         failures,
 		Queue:            taskQueue,
 		Judge:            judgeEngine,
-		ProblemReader:    problemService,
+		ProblemReader:    problemReader,
 		TestcaseResolver: testcaseResolver,
 		SourceStore:      sourceStore,
 		Metrics:          metrics,

--- a/internal/problem/archive_port.go
+++ b/internal/problem/archive_port.go
@@ -1,0 +1,17 @@
+package problem
+
+import (
+	"context"
+	"io"
+
+	"SOJ/internal/storage"
+)
+
+type testcaseArchiveReader interface {
+	Get(ctx context.Context, key string) (io.ReadCloser, storage.ObjectInfo, error)
+}
+
+type testcaseArchiveWriter interface {
+	Put(ctx context.Context, object storage.Object) (storage.ObjectInfo, error)
+	Delete(ctx context.Context, key string) error
+}

--- a/internal/problem/component_ports_test.go
+++ b/internal/problem/component_ports_test.go
@@ -1,0 +1,264 @@
+package problem
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"SOJ/internal/auth"
+	"SOJ/internal/storage"
+)
+
+type testcaseArchiveReaderStub struct{}
+
+func (testcaseArchiveReaderStub) Get(context.Context, string) (io.ReadCloser, storage.ObjectInfo, error) {
+	return nil, storage.ObjectInfo{}, nil
+}
+
+type testcaseArchiveWriterStub struct{}
+
+func (testcaseArchiveWriterStub) Put(context.Context, storage.Object) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, nil
+}
+
+func (testcaseArchiveWriterStub) Delete(context.Context, string) error {
+	return nil
+}
+
+type problemReaderStoreStub struct{}
+
+func (problemReaderStoreStub) GetProblem(context.Context, int64) (ProblemRecord, error) {
+	return ProblemRecord{ID: 7, OwnerUserID: 3, Status: StatusPublished, Visibility: VisibilityPublic}, nil
+}
+
+func (problemReaderStoreStub) ListProblems(context.Context, ListProblemsFilter) ([]ProblemRecord, error) {
+	return nil, nil
+}
+
+func (problemReaderStoreStub) ListProblemsByCursor(context.Context, ListProblemsFilter) ([]ProblemRecord, error) {
+	return nil, nil
+}
+
+func (problemReaderStoreStub) CountProblems(context.Context, ListProblemsFilter) (int64, error) {
+	return 0, nil
+}
+
+func (problemReaderStoreStub) GetCurrentProblemStatement(context.Context, int64) (Statement, error) {
+	return Statement{}, nil
+}
+
+func (problemReaderStoreStub) ListProblemTags(context.Context, int64) ([]Tag, error) {
+	return nil, nil
+}
+
+func (problemReaderStoreStub) GetCurrentReadyTestcaseSet(context.Context, int64) (TestcaseSetRecord, error) {
+	return TestcaseSetRecord{}, nil
+}
+
+func (problemReaderStoreStub) GetLatestCompletedProblemCheckRun(context.Context, int64, int64, int64) (ProblemCheckRunRecord, error) {
+	return ProblemCheckRunRecord{}, nil
+}
+
+func (problemReaderStoreStub) ListProblemCheckFindings(context.Context, int64) ([]ProblemCheckFindingRecord, error) {
+	return nil, nil
+}
+
+func (problemReaderStoreStub) GetProblemStats(context.Context, int64) (ProblemStats, error) {
+	return ProblemStats{}, nil
+}
+
+func TestProblemReaderUsesOnlyReadStore(t *testing.T) {
+	reader := NewProblemReader(problemReaderStoreStub{}, testcaseArchiveReaderStub{})
+
+	got, err := reader.GetProblem(t.Context(), auth.Actor{}, 7)
+	if err != nil {
+		t.Fatalf("GetProblem() error = %v", err)
+	}
+	if got.ID != 7 {
+		t.Fatalf("GetProblem().ID = %d, want 7", got.ID)
+	}
+}
+
+type problemAuthoringStoreStub struct {
+	tx problemAuthoringTxStub
+}
+
+func (s *problemAuthoringStoreStub) GetProblem(context.Context, int64) (ProblemRecord, error) {
+	return ProblemRecord{ID: 7, OwnerUserID: 3, Status: StatusDraft}, nil
+}
+
+func (s *problemAuthoringStoreStub) WithProblemAuthoringTx(ctx context.Context, fn func(context.Context, problemAuthoringTx) error) error {
+	return fn(ctx, &s.tx)
+}
+
+type problemAuthoringTxStub struct {
+	nextID int64
+}
+
+func (s *problemAuthoringTxStub) CreateProblem(_ context.Context, ownerUserID int64, input CreateProblemInput) (ProblemRecord, error) {
+	s.nextID++
+	return ProblemRecord{ID: s.nextID, OwnerUserID: ownerUserID, Title: input.Title, Status: StatusDraft}, nil
+}
+
+func (*problemAuthoringTxStub) LockProblemForUpdate(context.Context, int64) (ProblemRecord, error) {
+	return ProblemRecord{ID: 7, OwnerUserID: 3, Status: StatusDraft}, nil
+}
+
+func (*problemAuthoringTxStub) UpdateProblem(_ context.Context, id int64, _ UpdateProblemInput) (ProblemRecord, error) {
+	return ProblemRecord{ID: id, OwnerUserID: 3, Status: StatusDraft}, nil
+}
+
+func (*problemAuthoringTxStub) ArchiveProblem(_ context.Context, id int64) (ProblemRecord, error) {
+	return ProblemRecord{ID: id, OwnerUserID: 3, Status: StatusArchived}, nil
+}
+
+func (*problemAuthoringTxStub) NextProblemStatementVersion(context.Context, int64) (int32, error) {
+	return 1, nil
+}
+
+func (*problemAuthoringTxStub) ClearCurrentProblemStatement(context.Context, int64) error {
+	return nil
+}
+
+func (*problemAuthoringTxStub) CreateProblemStatement(_ context.Context, problemID int64, version int32, input CreateStatementInput) (Statement, error) {
+	return Statement{ID: 1, ProblemID: problemID, Version: version, Title: input.Title}, nil
+}
+
+func (*problemAuthoringTxStub) ReplaceProblemTags(context.Context, int64, []TagInput) ([]Tag, error) {
+	return nil, nil
+}
+
+func (*problemAuthoringTxStub) NextTestcaseSetVersion(context.Context, int64) (int32, error) {
+	return 1, nil
+}
+
+func (*problemAuthoringTxStub) ClearCurrentTestcaseSet(context.Context, int64) error {
+	return nil
+}
+
+func (*problemAuthoringTxStub) CreateTestcaseSet(_ context.Context, problemID int64, version int32, storageKey, checksum string, sizeBytes int64, caseCount int32, createdBy int64) (TestcaseSetRecord, error) {
+	return TestcaseSetRecord{ID: 1, ProblemID: problemID, Version: version, StorageKey: storageKey, ChecksumSHA256: checksum, SizeBytes: sizeBytes, CaseCount: caseCount, CreatedBy: createdBy}, nil
+}
+
+func (*problemAuthoringTxStub) CreateArtifact(_ context.Context, artifact ArtifactRecord) (ArtifactRecord, error) {
+	artifact.ID = 1
+	return artifact, nil
+}
+
+func (*problemAuthoringTxStub) GetCurrentProblemStatement(context.Context, int64) (Statement, error) {
+	return Statement{}, nil
+}
+
+func (*problemAuthoringTxStub) GetCurrentReadyTestcaseSet(context.Context, int64) (TestcaseSetRecord, error) {
+	return TestcaseSetRecord{}, nil
+}
+
+func (*problemAuthoringTxStub) GetLatestCompletedProblemCheckRun(context.Context, int64, int64, int64) (ProblemCheckRunRecord, error) {
+	return ProblemCheckRunRecord{}, nil
+}
+
+func (*problemAuthoringTxStub) ListProblemCheckFindings(context.Context, int64) ([]ProblemCheckFindingRecord, error) {
+	return nil, nil
+}
+
+func TestProblemAuthoringUsesOnlyAuthoringTransaction(t *testing.T) {
+	store := &problemAuthoringStoreStub{}
+	authoring := NewProblemAuthoring(store, testcaseArchiveWriterStub{})
+
+	created, err := authoring.CreateProblem(t.Context(), auth.Actor{UserID: 3, Role: auth.RoleUser}, CreateProblemInput{
+		Title:         "Sum",
+		Slug:          "sum",
+		Difficulty:    DifficultyEasy,
+		Visibility:    VisibilityPrivate,
+		TimeLimitMS:   1000,
+		MemoryLimitKB: 65536,
+	})
+	if err != nil {
+		t.Fatalf("CreateProblem() error = %v", err)
+	}
+	if created.ID == 0 || created.OwnerUserID != 3 {
+		t.Fatalf("CreateProblem() = %+v", created)
+	}
+}
+
+type problemCheckStoreStub struct{}
+
+func (problemCheckStoreStub) GetProblem(context.Context, int64) (ProblemRecord, error) {
+	return ProblemRecord{ID: 7, OwnerUserID: 3, Status: StatusDraft}, nil
+}
+
+func (problemCheckStoreStub) GetCurrentProblemStatement(context.Context, int64) (Statement, error) {
+	return Statement{}, nil
+}
+
+func (problemCheckStoreStub) GetCurrentReadyTestcaseSet(context.Context, int64) (TestcaseSetRecord, error) {
+	return TestcaseSetRecord{}, nil
+}
+
+func (problemCheckStoreStub) GetProblemCheckRun(_ context.Context, id int64) (ProblemCheckRunRecord, error) {
+	return ProblemCheckRunRecord{ID: id, ProblemID: 7, Status: ProblemCheckStatusCompleted}, nil
+}
+
+func (problemCheckStoreStub) ListProblemCheckFindings(context.Context, int64) ([]ProblemCheckFindingRecord, error) {
+	return nil, nil
+}
+
+func (problemCheckStoreStub) WithProblemCheckTx(ctx context.Context, fn func(context.Context, problemCheckTx) error) error {
+	return fn(ctx, problemCheckTxStub{})
+}
+
+type problemCheckTxStub struct{}
+
+func (problemCheckTxStub) CreateProblemCheckRun(_ context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return ProblemCheckRunRecord{ID: 1, ProblemID: input.ProblemID}, nil
+}
+
+func (problemCheckTxStub) CreateProblemCheckFinding(_ context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
+	return ProblemCheckFindingRecord{ID: 1, RunID: input.RunID}, nil
+}
+
+func (problemCheckTxStub) CompleteProblemCheckRun(_ context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
+	return ProblemCheckRunRecord{ID: input.ID, ProblemID: 7, Status: ProblemCheckStatusCompleted, FinishedAt: input.FinishedAt}, nil
+}
+
+func TestProblemCheckServiceUsesOnlyCheckStore(t *testing.T) {
+	checks := NewProblemCheckService(problemCheckStoreStub{}, testcaseArchiveReaderStub{}, func() time.Time { return time.Unix(10, 0).UTC() })
+
+	got, err := checks.GetProblemCheck(t.Context(), auth.Actor{UserID: 3, Role: auth.RoleUser}, 7, 9)
+	if err != nil {
+		t.Fatalf("GetProblemCheck() error = %v", err)
+	}
+	if got.Run.ID != 9 || got.Run.ProblemID != 7 {
+		t.Fatalf("GetProblemCheck() = %+v", got)
+	}
+}
+
+func TestProblemConstructorsRejectMissingRequiredDependencies(t *testing.T) {
+	reader := NewProblemReader(problemReaderStoreStub{}, testcaseArchiveReaderStub{})
+	authoring := NewProblemAuthoring(&problemAuthoringStoreStub{}, testcaseArchiveWriterStub{})
+	checks := NewProblemCheckService(problemCheckStoreStub{}, testcaseArchiveReaderStub{}, nil)
+
+	tests := []struct {
+		name string
+		new  func()
+	}{
+		{name: "reader store", new: func() { NewProblemReader(nil, testcaseArchiveReaderStub{}) }},
+		{name: "authoring store", new: func() { NewProblemAuthoring(nil, testcaseArchiveWriterStub{}) }},
+		{name: "check store", new: func() { NewProblemCheckService(nil, testcaseArchiveReaderStub{}, nil) }},
+		{name: "service reader", new: func() { NewService(nil, authoring, checks) }},
+		{name: "service authoring", new: func() { NewService(reader, nil, checks) }},
+		{name: "service checks", new: func() { NewService(reader, authoring, nil) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("constructor did not panic")
+				}
+			}()
+			tt.new()
+		})
+	}
+}

--- a/internal/problem/handler_test.go
+++ b/internal/problem/handler_test.go
@@ -50,7 +50,7 @@ func TestRunProblemCheckReturnsCreatedEnvelope(t *testing.T) {
 			}},
 		},
 	}
-	service := &Service{}
+	service := newProblemService(newFakeRepository(), &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
 		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
 	}})
@@ -98,7 +98,7 @@ func TestGetProblemCheckParsesCheckIDAndReturnsEnvelope(t *testing.T) {
 			Findings: []ProblemCheckFinding{},
 		},
 	}
-	service := &Service{}
+	service := newProblemService(newFakeRepository(), &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
 		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
 	}})
@@ -128,7 +128,7 @@ func TestGetProblemCheckParsesCheckIDAndReturnsEnvelope(t *testing.T) {
 
 func TestGetProblemCheckRejectsInvalidCheckID(t *testing.T) {
 	checks := &fakeProblemCheckService{}
-	service := &Service{}
+	service := newProblemService(newFakeRepository(), &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{
 		&Module{handler: &Handler{service: service, checkRunner: checks, checkGetter: checks}},
 	}})
@@ -152,7 +152,7 @@ func TestGetProblemCheckRejectsInvalidCheckID(t *testing.T) {
 func TestUploadTestcasesMissingArchiveReturnsTestcaseNotReady(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/problems/1/testcase-sets", strings.NewReader("case_count=1"))
@@ -173,7 +173,7 @@ func TestUploadTestcasesMissingArchiveReturnsTestcaseNotReady(t *testing.T) {
 func TestUploadTestcasesRejectsOversizedContentLengthBeforeMultipartParsing(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/problems/1/testcase-sets", strings.NewReader("archive=x"))
@@ -195,7 +195,7 @@ func TestUploadTestcasesRejectsOversizedContentLengthBeforeMultipartParsing(t *t
 func TestUploadTestcasesRejectsOversizedMultipartWithUnknownContentLength(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	handler := NewHandler(NewService(repo, &fakeStorage{}))
+	handler := NewHandler(newProblemService(repo, &fakeStorage{}))
 	router := httpapi.NewRouter(httpapi.RouterOptions{})
 	router.POST("/problems/:id/testcase-upload", func(c *gin.Context) {
 		handler.uploadTestcasesWithRequestLimit(c, 128)
@@ -237,7 +237,7 @@ func TestGetProblemAuthoringStateReturnsOwnerWorkspace(t *testing.T) {
 		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
 		Summary: json.RawMessage(`{"valid":true}`),
 	}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems/1/authoring", nil)
 	req.Header.Set("X-User-ID", "10")
@@ -263,7 +263,7 @@ func TestGetProblemAuthoringStateReturnsOwnerWorkspace(t *testing.T) {
 func TestListProblemsMineScopesRequestToCurrentUser(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Title: "Owned", Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	router := httpapi.NewRouter(httpapi.RouterOptions{Modules: []httpapi.Module{NewModule(service)}})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/problems?mine=true", nil)
 	req.Header.Set("X-User-ID", "10")
@@ -282,7 +282,7 @@ func TestListProblemsMineScopesRequestToCurrentUser(t *testing.T) {
 
 func TestCreateProblemStoresTags(t *testing.T) {
 	repo := newFakeRepository()
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	created, err := service.CreateProblem(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, CreateProblemInput{
 		Title:         "Two Sum",

--- a/internal/problem/problem_authoring.go
+++ b/internal/problem/problem_authoring.go
@@ -1,0 +1,256 @@
+package problem
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+	"SOJ/internal/storage"
+)
+
+type problemAuthoringStore interface {
+	GetProblem(ctx context.Context, id int64) (ProblemRecord, error)
+	WithProblemAuthoringTx(ctx context.Context, fn func(context.Context, problemAuthoringTx) error) error
+}
+
+type problemAuthoringTx interface {
+	CreateProblem(ctx context.Context, ownerUserID int64, input CreateProblemInput) (ProblemRecord, error)
+	UpdateProblem(ctx context.Context, id int64, input UpdateProblemInput) (ProblemRecord, error)
+	ArchiveProblem(ctx context.Context, id int64) (ProblemRecord, error)
+	LockProblemForUpdate(ctx context.Context, id int64) (ProblemRecord, error)
+	NextProblemStatementVersion(ctx context.Context, problemID int64) (int32, error)
+	ClearCurrentProblemStatement(ctx context.Context, problemID int64) error
+	CreateProblemStatement(ctx context.Context, problemID int64, version int32, input CreateStatementInput) (Statement, error)
+	ReplaceProblemTags(ctx context.Context, problemID int64, tags []TagInput) ([]Tag, error)
+	NextTestcaseSetVersion(ctx context.Context, problemID int64) (int32, error)
+	ClearCurrentTestcaseSet(ctx context.Context, problemID int64) error
+	CreateTestcaseSet(ctx context.Context, problemID int64, version int32, storageKey, checksum string, sizeBytes int64, caseCount int32, createdBy int64) (TestcaseSetRecord, error)
+	CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error)
+	problemPublishReadStore
+}
+
+// ProblemAuthoring owns problem creation and mutation workflows.
+type ProblemAuthoring struct {
+	store    problemAuthoringStore
+	archives testcaseArchiveWriter
+}
+
+// NewProblemAuthoring builds an authoring service with its transactional store and archive sink.
+// It panics if store is nil.
+func NewProblemAuthoring(store problemAuthoringStore, archives testcaseArchiveWriter) *ProblemAuthoring {
+	if store == nil {
+		panic("problem authoring store is required")
+	}
+	return &ProblemAuthoring{store: store, archives: archives}
+}
+
+func (a *ProblemAuthoring) CreateProblem(ctx context.Context, actor auth.Actor, input CreateProblemInput) (ProblemRecord, error) {
+	if err := requireAuthenticated(actor); err != nil {
+		return ProblemRecord{}, err
+	}
+	if err := validateCreateProblem(input); err != nil {
+		return ProblemRecord{}, err
+	}
+	tagInputs, err := tagInputsFromNames(input.Tags)
+	if err != nil {
+		return ProblemRecord{}, err
+	}
+	var created ProblemRecord
+	err = a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		var err error
+		created, err = tx.CreateProblem(ctx, actor.UserID, input)
+		if err != nil {
+			return err
+		}
+		if len(tagInputs) > 0 {
+			_, err = tx.ReplaceProblemTags(ctx, created.ID, tagInputs)
+		}
+		return err
+	})
+	return created, err
+}
+
+func (a *ProblemAuthoring) UpdateProblem(ctx context.Context, actor auth.Actor, id int64, input UpdateProblemInput) (ProblemRecord, error) {
+	var updated ProblemRecord
+	err := a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		current, err := tx.LockProblemForUpdate(ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := canWriteProblem(actor, current); err != nil {
+			return err
+		}
+		if input.Status != nil && *input.Status == StatusPublished {
+			if err := ensurePublishable(ctx, tx, id); err != nil {
+				return err
+			}
+		}
+		if err := validateUpdateProblem(input); err != nil {
+			return err
+		}
+		tagInputs, err := tagInputsFromNames(input.Tags)
+		if err != nil {
+			return err
+		}
+		updated, err = tx.UpdateProblem(ctx, id, input)
+		if err != nil {
+			return err
+		}
+		if input.Tags != nil {
+			_, err = tx.ReplaceProblemTags(ctx, id, tagInputs)
+		}
+		return err
+	})
+	return updated, err
+}
+
+func (a *ProblemAuthoring) ArchiveProblem(ctx context.Context, actor auth.Actor, id int64) (ProblemRecord, error) {
+	var archived ProblemRecord
+	err := a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		current, err := tx.LockProblemForUpdate(ctx, id)
+		if err != nil {
+			return err
+		}
+		if err := canWriteProblem(actor, current); err != nil {
+			return err
+		}
+		archived, err = tx.ArchiveProblem(ctx, id)
+		return err
+	})
+	return archived, err
+}
+
+func (a *ProblemAuthoring) CreateStatement(ctx context.Context, actor auth.Actor, problemID int64, input CreateStatementInput) (Statement, error) {
+	if !input.MakeCurrent {
+		input.MakeCurrent = true
+	}
+	if err := validateStatement(input); err != nil {
+		return Statement{}, err
+	}
+	var statement Statement
+	err := a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		p, err := tx.LockProblemForUpdate(ctx, problemID)
+		if err != nil {
+			return err
+		}
+		if err := canWriteProblem(actor, p); err != nil {
+			return err
+		}
+		version, err := tx.NextProblemStatementVersion(ctx, problemID)
+		if err != nil {
+			return err
+		}
+		if input.MakeCurrent {
+			if err := tx.ClearCurrentProblemStatement(ctx, problemID); err != nil {
+				return err
+			}
+		}
+		statement, err = tx.CreateProblemStatement(ctx, problemID, version, input)
+		if err != nil {
+			return err
+		}
+		return demotePublishedProblem(ctx, tx, p)
+	})
+	return statement, err
+}
+
+func (a *ProblemAuthoring) AssignTags(ctx context.Context, actor auth.Actor, problemID int64, input AssignTagsInput) ([]Tag, error) {
+	if err := validateTags(input.Tags); err != nil {
+		return nil, err
+	}
+	var tags []Tag
+	err := a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		p, err := tx.LockProblemForUpdate(ctx, problemID)
+		if err != nil {
+			return err
+		}
+		if err := canWriteProblem(actor, p); err != nil {
+			return err
+		}
+		tags, err = tx.ReplaceProblemTags(ctx, problemID, input.Tags)
+		return err
+	})
+	return tags, err
+}
+
+func (a *ProblemAuthoring) UploadTestcaseArchive(ctx context.Context, actor auth.Actor, problemID int64, input UploadTestcaseInput) (TestcaseSetRecord, error) {
+	if a.archives == nil {
+		return TestcaseSetRecord{}, apperror.ServiceUnavailable("object storage unavailable")
+	}
+	if err := validateTestcaseArchive(input.Content, input.CaseCount, input.ChecksumSHA256, defaultMaxTestcaseArchiveBytes); err != nil {
+		return TestcaseSetRecord{}, err
+	}
+	current, err := a.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return TestcaseSetRecord{}, err
+	}
+	if err := canWriteProblem(actor, current); err != nil {
+		return TestcaseSetRecord{}, err
+	}
+
+	actualChecksum := sha256Hex(input.Content)
+	contentType := input.ContentType
+	if contentType == "" {
+		contentType = "application/zip"
+	}
+	key, err := testcaseArchiveKey(problemID, actualChecksum)
+	if err != nil {
+		return TestcaseSetRecord{}, err
+	}
+	if _, err := a.archives.Put(ctx, storage.Object{
+		Key:         key,
+		ContentType: contentType,
+		Size:        int64(len(input.Content)),
+		Metadata: map[string]string{
+			"problem-id": fmt.Sprint(problemID),
+			"sha256":     actualChecksum,
+		},
+		Body: bytes.NewReader(input.Content),
+	}); err != nil {
+		return TestcaseSetRecord{}, err
+	}
+
+	var created TestcaseSetRecord
+	err = a.store.WithProblemAuthoringTx(ctx, func(ctx context.Context, tx problemAuthoringTx) error {
+		p, err := tx.LockProblemForUpdate(ctx, problemID)
+		if err != nil {
+			return err
+		}
+		if err := canWriteProblem(actor, p); err != nil {
+			return err
+		}
+		version, err := tx.NextTestcaseSetVersion(ctx, problemID)
+		if err != nil {
+			return err
+		}
+		artifact, err := tx.CreateArtifact(ctx, ArtifactRecord{
+			OwnerType:      "testcase",
+			OwnerID:        problemID,
+			Kind:           "testcase_archive",
+			StorageKey:     key,
+			ChecksumSHA256: actualChecksum,
+			SizeBytes:      int64(len(input.Content)),
+			ContentType:    contentType,
+		})
+		if err != nil {
+			return err
+		}
+		if artifact.ID == 0 {
+			return apperror.Internal()
+		}
+		if err := tx.ClearCurrentTestcaseSet(ctx, problemID); err != nil {
+			return err
+		}
+		created, err = tx.CreateTestcaseSet(ctx, problemID, version, key, actualChecksum, int64(len(input.Content)), input.CaseCount, actor.UserID)
+		if err != nil {
+			return err
+		}
+		return demotePublishedProblem(ctx, tx, p)
+	})
+	if err != nil {
+		_ = a.archives.Delete(ctx, key)
+	}
+	return created, err
+}

--- a/internal/problem/problem_check_service.go
+++ b/internal/problem/problem_check_service.go
@@ -1,0 +1,192 @@
+package problem
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+)
+
+type problemCheckStore interface {
+	GetProblem(ctx context.Context, id int64) (ProblemRecord, error)
+	GetCurrentProblemStatement(ctx context.Context, problemID int64) (Statement, error)
+	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
+	GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error)
+	ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error)
+	WithProblemCheckTx(ctx context.Context, fn func(context.Context, problemCheckTx) error) error
+}
+
+type problemCheckTx interface {
+	CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error)
+	CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error)
+	CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error)
+}
+
+// ProblemCheckService runs and reads problem validation checks.
+type ProblemCheckService struct {
+	store    problemCheckStore
+	archives testcaseArchiveReader
+	now      func() time.Time
+}
+
+// NewProblemCheckService builds a problem check service.
+// It panics if store is nil.
+func NewProblemCheckService(store problemCheckStore, archives testcaseArchiveReader, now func() time.Time) *ProblemCheckService {
+	if store == nil {
+		panic("problem check store is required")
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &ProblemCheckService{store: store, archives: archives, now: now}
+}
+
+func (s *ProblemCheckService) RunProblemCheck(ctx context.Context, actor auth.Actor, problemID int64) (ProblemCheckResult, error) {
+	p, err := s.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	statement, err := s.store.GetCurrentProblemStatement(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	set, err := s.store.GetCurrentReadyTestcaseSet(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	findings := validateProblemCheckStatementSamples(statement)
+	storageReadable := false
+	zipReadable := false
+	caseCount := 0
+	if s.archives == nil {
+		findings = append(findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.storage_unreadable",
+			message:  "testcase object storage is unavailable",
+			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+		})
+	} else if strings.TrimSpace(set.StorageKey) == "" {
+		findings = append(findings, problemCheckFindingDraft{
+			severity: ProblemCheckSeverityError,
+			code:     "testcase.storage_unreadable",
+			message:  "testcase archive storage key is missing",
+		})
+	} else {
+		body, _, err := s.archives.Get(ctx, set.StorageKey)
+		if err != nil {
+			findings = append(findings, problemCheckFindingDraft{
+				severity: ProblemCheckSeverityError,
+				code:     "testcase.storage_unreadable",
+				message:  "testcase archive cannot be read from storage",
+				details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+			})
+		} else {
+			storageReadable = true
+			data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
+			if err != nil {
+				if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
+					findings = append(findings, problemCheckFindingDraft{
+						severity: ProblemCheckSeverityError,
+						code:     resourceErr.code,
+						message:  resourceErr.message,
+						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+					})
+				} else {
+					storageReadable = false
+					findings = append(findings, problemCheckFindingDraft{
+						severity: ProblemCheckSeverityError,
+						code:     "testcase.storage_unreadable",
+						message:  "testcase archive cannot be read from storage",
+						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
+					})
+				}
+			} else {
+				archiveResult := validateProblemCheckArchive(data, set)
+				zipReadable = archiveResult.zipReadable
+				caseCount = archiveResult.caseCount
+				findings = append(findings, archiveResult.findings...)
+			}
+		}
+	}
+
+	summary := problemCheckSummary(set.CaseCount, caseCount, storageReadable, zipReadable, findings)
+	summaryJSON, err := marshalProblemCheckSummary(summary)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+
+	var runRecord ProblemCheckRunRecord
+	persistedFindings := make([]ProblemCheckFinding, 0, len(findings))
+	err = s.store.WithProblemCheckTx(ctx, func(ctx context.Context, tx problemCheckTx) error {
+		run, err := tx.CreateProblemCheckRun(ctx, CreateProblemCheckRunInput{
+			ProblemID:     problemID,
+			StatementID:   statement.ID,
+			TestcaseSetID: set.ID,
+			RequestedBy:   actor.UserID,
+			Status:        ProblemCheckStatusRunning,
+			Summary:       json.RawMessage(`{}`),
+		})
+		if err != nil {
+			return err
+		}
+		for _, finding := range findings {
+			record, err := tx.CreateProblemCheckFinding(ctx, CreateProblemCheckFindingInput{
+				RunID:       run.ID,
+				Severity:    finding.severity,
+				Code:        finding.code,
+				Message:     finding.message,
+				CaseIndex:   finding.caseIndex,
+				TestcaseKey: finding.testcaseKey,
+				Details:     finding.details,
+			})
+			if err != nil {
+				return err
+			}
+			persistedFindings = append(persistedFindings, problemCheckFindingFromRecord(record))
+		}
+		runRecord, err = tx.CompleteProblemCheckRun(ctx, CompleteProblemCheckRunInput{
+			ID:         run.ID,
+			Summary:    summaryJSON,
+			FinishedAt: s.now(),
+		})
+		return err
+	})
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	return ProblemCheckResult{Run: problemCheckRunFromRecord(runRecord), Findings: persistedFindings}, nil
+}
+
+func (s *ProblemCheckService) GetProblemCheck(ctx context.Context, actor auth.Actor, problemID int64, checkID int64) (ProblemCheckResult, error) {
+	p, err := s.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemCheckResult{}, err
+	}
+	run, err := s.store.GetProblemCheckRun(ctx, checkID)
+	if err != nil {
+		return ProblemCheckResult{}, problemCheckNotFoundErr(err)
+	}
+	if run.ProblemID != problemID {
+		return ProblemCheckResult{}, apperror.NotFound("problem_check.not_found", "problem check not found")
+	}
+	records, err := s.store.ListProblemCheckFindings(ctx, checkID)
+	if err != nil {
+		return ProblemCheckResult{}, err
+	}
+	findings := make([]ProblemCheckFinding, 0, len(records))
+	for _, record := range records {
+		findings = append(findings, problemCheckFindingFromRecord(record))
+	}
+	return ProblemCheckResult{Run: problemCheckRunFromRecord(run), Findings: findings}, nil
+}

--- a/internal/problem/problem_reader.go
+++ b/internal/problem/problem_reader.go
@@ -1,0 +1,268 @@
+package problem
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+)
+
+type problemReaderStore interface {
+	GetProblem(ctx context.Context, id int64) (ProblemRecord, error)
+	ListProblems(ctx context.Context, filter ListProblemsFilter) ([]ProblemRecord, error)
+	ListProblemsByCursor(ctx context.Context, filter ListProblemsFilter) ([]ProblemRecord, error)
+	CountProblems(ctx context.Context, filter ListProblemsFilter) (int64, error)
+	GetCurrentProblemStatement(ctx context.Context, problemID int64) (Statement, error)
+	ListProblemTags(ctx context.Context, problemID int64) ([]Tag, error)
+	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
+	GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error)
+	ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error)
+	GetProblemStats(ctx context.Context, problemID int64) (ProblemStats, error)
+}
+
+// ProblemReader serves all non-mutating problem workflows.
+type ProblemReader struct {
+	store    problemReaderStore
+	archives testcaseArchiveReader
+}
+
+// NewProblemReader builds a reader with its query store and testcase archive source.
+// It panics if store is nil.
+func NewProblemReader(store problemReaderStore, archives testcaseArchiveReader) *ProblemReader {
+	if store == nil {
+		panic("problem reader store is required")
+	}
+	return &ProblemReader{store: store, archives: archives}
+}
+
+func (r *ProblemReader) GetProblem(ctx context.Context, actor auth.Actor, id int64) (ProblemRecord, error) {
+	p, err := r.store.GetProblem(ctx, id)
+	if err != nil {
+		return ProblemRecord{}, err
+	}
+	if err := canReadProblem(actor, p); err != nil {
+		return ProblemRecord{}, err
+	}
+	return p, nil
+}
+
+func (r *ProblemReader) ListProblems(ctx context.Context, actor auth.Actor, filter ListProblemsFilter) (ProblemList, error) {
+	if filter.Mine && !actor.Authenticated() {
+		return ProblemList{}, requireAuthenticated(actor)
+	}
+	filter = normalizeListFilter(actor, filter)
+	items, err := r.store.ListProblems(ctx, filter)
+	if err != nil {
+		return ProblemList{}, err
+	}
+	total, err := r.store.CountProblems(ctx, filter)
+	if err != nil {
+		return ProblemList{}, err
+	}
+	responses := make([]ProblemResponse, 0, len(items))
+	for _, item := range items {
+		response, err := r.ProblemResponse(ctx, item)
+		if err != nil {
+			return ProblemList{}, err
+		}
+		responses = append(responses, response)
+	}
+	return ProblemList{Items: responses, Total: total, Page: filter.Page, PageSize: filter.PageSize}, nil
+}
+
+func (r *ProblemReader) ListProblemsByCursor(ctx context.Context, actor auth.Actor, filter ListProblemsFilter) (ProblemCursorPage, error) {
+	if filter.Mine && !actor.Authenticated() {
+		return ProblemCursorPage{}, requireAuthenticated(actor)
+	}
+	filter = normalizeListFilter(actor, filter)
+	limit := filter.PageSize
+	cursor := ProblemCursor{
+		CreatedAt: time.Date(9999, time.December, 31, 23, 59, 59, 999999999, time.UTC),
+		ID:        1<<63 - 1,
+	}
+	if filter.Cursor != nil {
+		if filter.Cursor.ID <= 0 || filter.Cursor.CreatedAt.IsZero() {
+			return ProblemCursorPage{}, apperror.BadRequest("invalid_cursor", "cursor is invalid")
+		}
+		cursor = ProblemCursor{CreatedAt: filter.Cursor.CreatedAt.UTC(), ID: filter.Cursor.ID}
+	}
+	filter.Cursor = &cursor
+	filter.Limit = limit + 1
+	filter.Offset = 0
+	items, err := r.store.ListProblemsByCursor(ctx, filter)
+	if err != nil {
+		return ProblemCursorPage{}, err
+	}
+	hasMore := len(items) > int(limit)
+	if hasMore {
+		items = items[:limit]
+	}
+	responses := make([]ProblemResponse, 0, len(items))
+	for _, item := range items {
+		response, err := r.ProblemResponse(ctx, item)
+		if err != nil {
+			return ProblemCursorPage{}, err
+		}
+		responses = append(responses, response)
+	}
+	page := ProblemCursorPage{Items: responses}
+	if hasMore {
+		last := items[len(items)-1]
+		page.NextCursor = &ProblemCursor{CreatedAt: last.CreatedAt, ID: last.ID}
+	}
+	return page, nil
+}
+
+func (r *ProblemReader) GetProblemAuthoringState(ctx context.Context, actor auth.Actor, id int64) (ProblemAuthoringState, error) {
+	p, err := r.store.GetProblem(ctx, id)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	if err := canWriteProblem(actor, p); err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	response, err := r.ProblemResponse(ctx, p)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	readiness, err := loadProblemAuthoringReadiness(ctx, r.store, id)
+	if err != nil {
+		return ProblemAuthoringState{}, err
+	}
+	return ProblemAuthoringState{
+		Problem:     response,
+		Statement:   readiness.statement,
+		TestcaseSet: readiness.testcaseSet,
+		LatestCheck: readiness.latestCheck,
+		Publishable: len(readiness.blockers) == 0,
+		Blockers:    readiness.blockers,
+	}, nil
+}
+
+func (r *ProblemReader) CurrentStatement(ctx context.Context, actor auth.Actor, problemID int64) (Statement, error) {
+	p, err := r.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return Statement{}, err
+	}
+	if err := canReadProblem(actor, p); err != nil {
+		return Statement{}, err
+	}
+	return r.store.GetCurrentProblemStatement(ctx, problemID)
+}
+
+func (r *ProblemReader) ProblemResponse(ctx context.Context, p ProblemRecord) (ProblemResponse, error) {
+	tags, err := r.store.ListProblemTags(ctx, p.ID)
+	if err != nil {
+		return ProblemResponse{}, err
+	}
+	tagNames := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tagNames = append(tagNames, tag.Name)
+	}
+	return ProblemResponse{
+		ID:         p.ID,
+		Title:      p.Title,
+		Slug:       p.Slug,
+		Difficulty: p.Difficulty,
+		Visibility: p.Visibility,
+		Status:     p.Status,
+		Tags:       tagNames,
+		Limits: ProblemLimits{
+			TimeLimitMS:   p.TimeLimitMS,
+			MemoryLimitKB: p.MemoryLimitKB,
+		},
+		OwnerUserID: p.OwnerUserID,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+		PublishedAt: p.PublishedAt,
+	}, nil
+}
+
+func (r *ProblemReader) CurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSet, error) {
+	set, err := r.store.GetCurrentReadyTestcaseSet(ctx, problemID)
+	if err != nil {
+		return TestcaseSet{}, err
+	}
+	if r.archives == nil {
+		return TestcaseSet{}, apperror.ServiceUnavailable("testcase object storage unavailable")
+	}
+	if strings.TrimSpace(set.StorageKey) == "" {
+		return TestcaseSet{}, apperror.BadRequest("testcase.archive_missing", "testcase archive storage key is missing")
+	}
+	p, err := r.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return TestcaseSet{}, err
+	}
+	body, _, err := r.archives.Get(ctx, set.StorageKey)
+	if err != nil {
+		return TestcaseSet{}, err
+	}
+	data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
+	if err != nil {
+		if _, ok := err.(*testcaseArchiveResourceError); ok {
+			return TestcaseSet{}, testcaseArchiveBadRequest(err)
+		}
+		return TestcaseSet{}, err
+	}
+	cases, err := parseTestcaseArchiveCases(data, time.Duration(p.TimeLimitMS)*time.Millisecond, int64(p.MemoryLimitKB))
+	if err != nil {
+		return TestcaseSet{}, err
+	}
+	if set.CaseCount > 0 && int32(len(cases)) != set.CaseCount {
+		return TestcaseSet{}, apperror.BadRequest("testcase.case_count_mismatch", "case_count does not match input/output pairs")
+	}
+	return TestcaseSet{
+		ID:        set.ID,
+		ProblemID: set.ProblemID,
+		Version:   int(set.Version),
+		Status:    set.Status,
+		Cases:     cases,
+	}, nil
+}
+
+func (r *ProblemReader) GetForJudge(ctx context.Context, problemID int64) (Problem, error) {
+	p, err := r.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return Problem{}, err
+	}
+	if p.Status != StatusPublished || p.CurrentStatementID == 0 || p.CurrentTestcaseSetID == 0 || p.CurrentTestcaseStatus != TestcaseStatusReady {
+		return Problem{}, apperror.NotFound("problem.not_ready", "problem is not ready for judge")
+	}
+	return Problem{
+		ID:                   p.ID,
+		Slug:                 p.Slug,
+		Title:                p.Title,
+		Visibility:           p.Visibility,
+		OwnerUserID:          p.OwnerUserID,
+		CurrentStatementID:   p.CurrentStatementID,
+		CurrentTestcaseSetID: p.CurrentTestcaseSetID,
+	}, nil
+}
+
+func (r *ProblemReader) AuthorizeProblemRejudge(ctx context.Context, actor auth.Actor, id int64) error {
+	p, err := r.store.GetProblem(ctx, id)
+	if err != nil {
+		return err
+	}
+	return canWriteProblem(actor, p)
+}
+
+func (r *ProblemReader) Stats(ctx context.Context, actor auth.Actor, problemID int64) (ProblemStats, error) {
+	p, err := r.store.GetProblem(ctx, problemID)
+	if err != nil {
+		return ProblemStats{}, err
+	}
+	if err := canReadProblem(actor, p); err != nil {
+		return ProblemStats{}, err
+	}
+	stats, err := r.store.GetProblemStats(ctx, problemID)
+	if err != nil {
+		return ProblemStats{}, err
+	}
+	if stats.TotalSubmissions > 0 {
+		stats.AcceptanceRate = float64(stats.AcceptedSubmissions) / float64(stats.TotalSubmissions)
+	}
+	return stats, nil
+}

--- a/internal/problem/problem_readiness.go
+++ b/internal/problem/problem_readiness.go
@@ -1,0 +1,101 @@
+package problem
+
+import (
+	"context"
+	"net/http"
+
+	"SOJ/internal/apperror"
+)
+
+type problemPublishReadStore interface {
+	GetCurrentProblemStatement(ctx context.Context, problemID int64) (Statement, error)
+	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
+	GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error)
+	ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error)
+}
+
+type problemStatusUpdater interface {
+	UpdateProblem(ctx context.Context, id int64, input UpdateProblemInput) (ProblemRecord, error)
+}
+
+type problemAuthoringReadiness struct {
+	statement   *Statement
+	testcaseSet *TestcaseSetRecord
+	latestCheck *ProblemCheckRun
+	blockers    []ProblemAuthoringBlocker
+}
+
+func ensurePublishable(ctx context.Context, store problemPublishReadStore, problemID int64) error {
+	readiness, err := loadProblemAuthoringReadiness(ctx, store, problemID)
+	if err != nil {
+		return err
+	}
+	if len(readiness.blockers) > 0 {
+		blocker := readiness.blockers[0]
+		return apperror.Unprocessable(blocker.Code, blocker.Message)
+	}
+	return nil
+}
+
+func demotePublishedProblem(ctx context.Context, store problemStatusUpdater, problem ProblemRecord) error {
+	if problem.Status != StatusPublished {
+		return nil
+	}
+	status := StatusDraft
+	_, err := store.UpdateProblem(ctx, problem.ID, UpdateProblemInput{Status: &status})
+	return err
+}
+
+func loadProblemAuthoringReadiness(ctx context.Context, store problemPublishReadStore, problemID int64) (problemAuthoringReadiness, error) {
+	state := problemAuthoringReadiness{blockers: []ProblemAuthoringBlocker{}}
+	statement, err := store.GetCurrentProblemStatement(ctx, problemID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.statement_required", Message: "current statement is required before publishing"})
+	} else {
+		state.statement = &statement
+	}
+
+	testcaseSet, err := store.GetCurrentReadyTestcaseSet(ctx, problemID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.testcase_required", Message: "current ready testcase set is required before publishing"})
+		return state, nil
+	}
+	state.testcaseSet = &testcaseSet
+
+	if state.statement == nil {
+		return state, nil
+	}
+	runRecord, err := store.GetLatestCompletedProblemCheckRun(ctx, problemID, state.statement.ID, testcaseSet.ID)
+	if err != nil {
+		if !isNotFoundError(err) {
+			return problemAuthoringReadiness{}, err
+		}
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_required", Message: "run a problem check for the current testcase set before publishing"})
+		return state, nil
+	}
+	run := problemCheckRunFromRecord(runRecord)
+	findings, err := store.ListProblemCheckFindings(ctx, run.ID)
+	if err != nil {
+		return problemAuthoringReadiness{}, err
+	}
+	run.Findings = make([]ProblemCheckFinding, 0, len(findings))
+	for _, finding := range findings {
+		run.Findings = append(run.Findings, problemCheckFindingFromRecord(finding))
+	}
+	state.latestCheck = &run
+	if !run.Summary.Valid {
+		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_failed", Message: "the current testcase set has validation errors"})
+	}
+	return state, nil
+}
+
+func isNotFoundError(err error) bool {
+	appErr, ok := apperror.From(err)
+	return ok && appErr.HTTPStatus == http.StatusNotFound
+}

--- a/internal/problem/repository.go
+++ b/internal/problem/repository.go
@@ -17,39 +17,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-type Repository interface {
-	WithTx(ctx context.Context, fn func(context.Context, Repository) error) error
-	CreateProblem(ctx context.Context, ownerUserID int64, input CreateProblemInput) (ProblemRecord, error)
-	GetProblem(ctx context.Context, id int64) (ProblemRecord, error)
-	ListProblems(ctx context.Context, filter ListProblemsFilter) ([]ProblemRecord, error)
-	ListProblemsByCursor(ctx context.Context, filter ListProblemsFilter) ([]ProblemRecord, error)
-	CountProblems(ctx context.Context, filter ListProblemsFilter) (int64, error)
-	UpdateProblem(ctx context.Context, id int64, input UpdateProblemInput) (ProblemRecord, error)
-	ArchiveProblem(ctx context.Context, id int64) (ProblemRecord, error)
-	LockProblemForUpdate(ctx context.Context, id int64) (ProblemRecord, error)
-	NextProblemStatementVersion(ctx context.Context, problemID int64) (int32, error)
-	ClearCurrentProblemStatement(ctx context.Context, problemID int64) error
-	CreateProblemStatement(ctx context.Context, problemID int64, version int32, input CreateStatementInput) (Statement, error)
-	GetCurrentProblemStatement(ctx context.Context, problemID int64) (Statement, error)
-	ReplaceProblemTags(ctx context.Context, problemID int64, tags []TagInput) ([]Tag, error)
-	ListProblemTags(ctx context.Context, problemID int64) ([]Tag, error)
-	NextTestcaseSetVersion(ctx context.Context, problemID int64) (int32, error)
-	ClearCurrentTestcaseSet(ctx context.Context, problemID int64) error
-	CreateTestcaseSet(ctx context.Context, problemID int64, version int32, storageKey, checksum string, sizeBytes int64, caseCount int32, createdBy int64) (TestcaseSetRecord, error)
-	GetCurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSetRecord, error)
-	CreateProblemCheckRun(ctx context.Context, input CreateProblemCheckRunInput) (ProblemCheckRunRecord, error)
-	GetProblemCheckRun(ctx context.Context, id int64) (ProblemCheckRunRecord, error)
-	GetLatestCompletedProblemCheckRun(ctx context.Context, problemID, statementID, testcaseSetID int64) (ProblemCheckRunRecord, error)
-	ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error)
-	CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error)
-	FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error)
-	CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error)
-	GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error)
-	ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error)
-	CreateArtifact(ctx context.Context, artifact ArtifactRecord) (ArtifactRecord, error)
-	GetProblemStats(ctx context.Context, problemID int64) (ProblemStats, error)
-}
-
 type CreateProblemCheckRunInput struct {
 	ProblemID     int64
 	StatementID   int64
@@ -59,23 +26,10 @@ type CreateProblemCheckRunInput struct {
 	Summary       json.RawMessage
 }
 
-type ListProblemCheckRunsFilter struct {
-	ProblemID int64
-	Offset    int32
-	Limit     int32
-}
-
 type CompleteProblemCheckRunInput struct {
 	ID         int64
 	Summary    json.RawMessage
 	FinishedAt time.Time
-}
-
-type FailProblemCheckRunInput struct {
-	ID           int64
-	Summary      json.RawMessage
-	ErrorMessage string
-	FinishedAt   time.Time
 }
 
 type CreateProblemCheckFindingInput struct {
@@ -124,9 +78,21 @@ func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
 	return &PostgresRepository{pool: pool, queries: db.New(pool)}
 }
 
-func (r *PostgresRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
+func (r *PostgresRepository) withTx(ctx context.Context, fn func(*txRepository) error) error {
 	return postgres.WithPoolTx(ctx, r.pool, func(tx pgx.Tx) error {
-		return fn(ctx, &txRepository{queries: r.queries.WithTx(tx)})
+		return fn(&txRepository{queries: r.queries.WithTx(tx)})
+	})
+}
+
+func (r *PostgresRepository) WithProblemAuthoringTx(ctx context.Context, fn func(context.Context, problemAuthoringTx) error) error {
+	return r.withTx(ctx, func(tx *txRepository) error {
+		return fn(ctx, tx)
+	})
+}
+
+func (r *PostgresRepository) WithProblemCheckTx(ctx context.Context, fn func(context.Context, problemCheckTx) error) error {
+	return r.withTx(ctx, func(tx *txRepository) error {
+		return fn(ctx, tx)
 	})
 }
 
@@ -262,25 +228,12 @@ func (r *PostgresRepository) GetLatestCompletedProblemCheckRun(ctx context.Conte
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }
 
-func (r *PostgresRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
-	return listProblemCheckRuns(ctx, r.queries, filter)
-}
-
 func (r *PostgresRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
 	return completeProblemCheckRun(ctx, r.queries, input)
 }
 
-func (r *PostgresRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
-	return failProblemCheckRun(ctx, r.queries, input)
-}
-
 func (r *PostgresRepository) CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
 	return createProblemCheckFinding(ctx, r.queries, input)
-}
-
-func (r *PostgresRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
-	finding, err := r.queries.GetProblemCheckFindingByID(ctx, id)
-	return problemCheckFindingFromDB(finding), mapDBErr(err)
 }
 
 func (r *PostgresRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {
@@ -298,10 +251,6 @@ func (r *PostgresRepository) GetProblemStats(ctx context.Context, problemID int6
 
 type txRepository struct {
 	queries *db.Queries
-}
-
-func (r *txRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
-	return fn(ctx, r)
 }
 
 func (r *txRepository) CreateProblem(ctx context.Context, ownerUserID int64, input CreateProblemInput) (ProblemRecord, error) {
@@ -464,25 +413,12 @@ func (r *txRepository) GetLatestCompletedProblemCheckRun(ctx context.Context, pr
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }
 
-func (r *txRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
-	return listProblemCheckRuns(ctx, r.queries, filter)
-}
-
 func (r *txRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
 	return completeProblemCheckRun(ctx, r.queries, input)
 }
 
-func (r *txRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
-	return failProblemCheckRun(ctx, r.queries, input)
-}
-
 func (r *txRepository) CreateProblemCheckFinding(ctx context.Context, input CreateProblemCheckFindingInput) (ProblemCheckFindingRecord, error) {
 	return createProblemCheckFinding(ctx, r.queries, input)
-}
-
-func (r *txRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
-	finding, err := r.queries.GetProblemCheckFindingByID(ctx, id)
-	return problemCheckFindingFromDB(finding), mapDBErr(err)
 }
 
 func (r *txRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {
@@ -593,37 +529,11 @@ func createProblemCheckRun(ctx context.Context, q *db.Queries, input CreateProbl
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }
 
-func listProblemCheckRuns(ctx context.Context, q *db.Queries, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
-	rows, err := q.ListProblemCheckRunsByProblemID(ctx, db.ListProblemCheckRunsByProblemIDParams{
-		ProblemID: filter.ProblemID,
-		Offset:    filter.Offset,
-		Limit:     filter.Limit,
-	})
-	if err != nil {
-		return nil, mapDBErr(err)
-	}
-	runs := make([]ProblemCheckRunRecord, 0, len(rows))
-	for _, row := range rows {
-		runs = append(runs, problemCheckRunFromDB(row))
-	}
-	return runs, nil
-}
-
 func completeProblemCheckRun(ctx context.Context, q *db.Queries, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
 	run, err := q.CompleteProblemCheckRun(ctx, db.CompleteProblemCheckRunParams{
 		ID:         input.ID,
 		Summary:    jsonbArg(input.Summary),
 		FinishedAt: timeArg(input.FinishedAt),
-	})
-	return problemCheckRunFromDB(run), mapDBErr(err)
-}
-
-func failProblemCheckRun(ctx context.Context, q *db.Queries, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
-	run, err := q.FailProblemCheckRun(ctx, db.FailProblemCheckRunParams{
-		ID:           input.ID,
-		Summary:      jsonbArg(input.Summary),
-		ErrorMessage: textValue(input.ErrorMessage),
-		FinishedAt:   timeArg(input.FinishedAt),
 	})
 	return problemCheckRunFromDB(run), mapDBErr(err)
 }

--- a/internal/problem/service.go
+++ b/internal/problem/service.go
@@ -20,7 +20,6 @@ import (
 
 	"SOJ/internal/apperror"
 	"SOJ/internal/auth"
-	"SOJ/internal/storage"
 )
 
 const (
@@ -282,682 +281,98 @@ type ProblemAuthoringState struct {
 	Blockers    []ProblemAuthoringBlocker `json:"blockers"`
 }
 
+// Service is the public problem API composed from focused collaborators.
 type Service struct {
-	repo    Repository
-	storage storage.ObjectStorage
-	now     func() time.Time
+	reader    *ProblemReader
+	authoring *ProblemAuthoring
+	checks    *ProblemCheckService
 }
 
-func NewService(repo Repository, objectStorage storage.ObjectStorage) *Service {
-	return &Service{repo: repo, storage: objectStorage, now: time.Now}
+// NewService composes the public problem API.
+// It panics if a collaborator is nil.
+func NewService(reader *ProblemReader, authoring *ProblemAuthoring, checks *ProblemCheckService) *Service {
+	if reader == nil {
+		panic("problem reader is required")
+	}
+	if authoring == nil {
+		panic("problem authoring is required")
+	}
+	if checks == nil {
+		panic("problem check service is required")
+	}
+	return &Service{reader: reader, authoring: authoring, checks: checks}
 }
 
 func (s *Service) CreateProblem(ctx context.Context, actor auth.Actor, input CreateProblemInput) (ProblemRecord, error) {
-	if err := requireAuthenticated(actor); err != nil {
-		return ProblemRecord{}, err
-	}
-	if err := validateCreateProblem(input); err != nil {
-		return ProblemRecord{}, err
-	}
-	tagInputs, err := tagInputsFromNames(input.Tags)
-	if err != nil {
-		return ProblemRecord{}, err
-	}
-	var created ProblemRecord
-	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		var err error
-		created, err = repo.CreateProblem(ctx, actor.UserID, input)
-		if err != nil {
-			return err
-		}
-		if len(tagInputs) > 0 {
-			_, err = repo.ReplaceProblemTags(ctx, created.ID, tagInputs)
-		}
-		return err
-	})
-	return created, err
+	return s.authoring.CreateProblem(ctx, actor, input)
 }
 
 func (s *Service) GetProblem(ctx context.Context, actor auth.Actor, id int64) (ProblemRecord, error) {
-	p, err := s.repo.GetProblem(ctx, id)
-	if err != nil {
-		return ProblemRecord{}, err
-	}
-	if err := canReadProblem(actor, p); err != nil {
-		return ProblemRecord{}, err
-	}
-	return p, nil
+	return s.reader.GetProblem(ctx, actor, id)
 }
 
 func (s *Service) ListProblems(ctx context.Context, actor auth.Actor, filter ListProblemsFilter) (ProblemList, error) {
-	if filter.Mine && !actor.Authenticated() {
-		return ProblemList{}, requireAuthenticated(actor)
-	}
-	filter = normalizeListFilter(actor, filter)
-	items, err := s.repo.ListProblems(ctx, filter)
-	if err != nil {
-		return ProblemList{}, err
-	}
-	total, err := s.repo.CountProblems(ctx, filter)
-	if err != nil {
-		return ProblemList{}, err
-	}
-	responses := make([]ProblemResponse, 0, len(items))
-	for _, item := range items {
-		response, err := s.ProblemResponse(ctx, item)
-		if err != nil {
-			return ProblemList{}, err
-		}
-		responses = append(responses, response)
-	}
-	return ProblemList{Items: responses, Total: total, Page: filter.Page, PageSize: filter.PageSize}, nil
+	return s.reader.ListProblems(ctx, actor, filter)
 }
 
 func (s *Service) ListProblemsByCursor(ctx context.Context, actor auth.Actor, filter ListProblemsFilter) (ProblemCursorPage, error) {
-	if filter.Mine && !actor.Authenticated() {
-		return ProblemCursorPage{}, requireAuthenticated(actor)
-	}
-	filter = normalizeListFilter(actor, filter)
-	limit := filter.PageSize
-	cursor := ProblemCursor{
-		CreatedAt: time.Date(9999, time.December, 31, 23, 59, 59, 999999999, time.UTC),
-		ID:        1<<63 - 1,
-	}
-	if filter.Cursor != nil {
-		if filter.Cursor.ID <= 0 || filter.Cursor.CreatedAt.IsZero() {
-			return ProblemCursorPage{}, apperror.BadRequest("invalid_cursor", "cursor is invalid")
-		}
-		cursor = ProblemCursor{CreatedAt: filter.Cursor.CreatedAt.UTC(), ID: filter.Cursor.ID}
-	}
-	filter.Cursor = &cursor
-	filter.Limit = limit + 1
-	filter.Offset = 0
-	items, err := s.repo.ListProblemsByCursor(ctx, filter)
-	if err != nil {
-		return ProblemCursorPage{}, err
-	}
-	hasMore := len(items) > int(limit)
-	if hasMore {
-		items = items[:limit]
-	}
-	responses := make([]ProblemResponse, 0, len(items))
-	for _, item := range items {
-		response, err := s.ProblemResponse(ctx, item)
-		if err != nil {
-			return ProblemCursorPage{}, err
-		}
-		responses = append(responses, response)
-	}
-	page := ProblemCursorPage{Items: responses}
-	if hasMore {
-		last := items[len(items)-1]
-		page.NextCursor = &ProblemCursor{CreatedAt: last.CreatedAt, ID: last.ID}
-	}
-	return page, nil
+	return s.reader.ListProblemsByCursor(ctx, actor, filter)
 }
 
 func (s *Service) GetProblemAuthoringState(ctx context.Context, actor auth.Actor, id int64) (ProblemAuthoringState, error) {
-	p, err := s.repo.GetProblem(ctx, id)
-	if err != nil {
-		return ProblemAuthoringState{}, err
-	}
-	if err := canWriteProblem(actor, p); err != nil {
-		return ProblemAuthoringState{}, err
-	}
-	response, err := s.ProblemResponse(ctx, p)
-	if err != nil {
-		return ProblemAuthoringState{}, err
-	}
-	readiness, err := loadProblemAuthoringReadiness(ctx, s.repo, id)
-	if err != nil {
-		return ProblemAuthoringState{}, err
-	}
-	return ProblemAuthoringState{
-		Problem:     response,
-		Statement:   readiness.statement,
-		TestcaseSet: readiness.testcaseSet,
-		LatestCheck: readiness.latestCheck,
-		Publishable: len(readiness.blockers) == 0,
-		Blockers:    readiness.blockers,
-	}, nil
+	return s.reader.GetProblemAuthoringState(ctx, actor, id)
 }
 
 func (s *Service) UpdateProblem(ctx context.Context, actor auth.Actor, id int64, input UpdateProblemInput) (ProblemRecord, error) {
-	var updated ProblemRecord
-	err := s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		current, err := repo.LockProblemForUpdate(ctx, id)
-		if err != nil {
-			return err
-		}
-		if err := canWriteProblem(actor, current); err != nil {
-			return err
-		}
-		if input.Status != nil && *input.Status == StatusPublished {
-			if err := ensurePublishable(ctx, repo, id); err != nil {
-				return err
-			}
-		}
-		if err := validateUpdateProblem(input); err != nil {
-			return err
-		}
-		tagInputs, err := tagInputsFromNames(input.Tags)
-		if err != nil {
-			return err
-		}
-		updated, err = repo.UpdateProblem(ctx, id, input)
-		if err != nil {
-			return err
-		}
-		if input.Tags != nil {
-			_, err = repo.ReplaceProblemTags(ctx, id, tagInputs)
-		}
-		return err
-	})
-	return updated, err
+	return s.authoring.UpdateProblem(ctx, actor, id, input)
 }
 
 func (s *Service) ArchiveProblem(ctx context.Context, actor auth.Actor, id int64) (ProblemRecord, error) {
-	var archived ProblemRecord
-	err := s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		current, err := repo.LockProblemForUpdate(ctx, id)
-		if err != nil {
-			return err
-		}
-		if err := canWriteProblem(actor, current); err != nil {
-			return err
-		}
-		archived, err = repo.ArchiveProblem(ctx, id)
-		return err
-	})
-	return archived, err
+	return s.authoring.ArchiveProblem(ctx, actor, id)
 }
 
 func (s *Service) CreateStatement(ctx context.Context, actor auth.Actor, problemID int64, input CreateStatementInput) (Statement, error) {
-	if !input.MakeCurrent {
-		input.MakeCurrent = true
-	}
-	if err := validateStatement(input); err != nil {
-		return Statement{}, err
-	}
-	var statement Statement
-	err := s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		p, err := repo.LockProblemForUpdate(ctx, problemID)
-		if err != nil {
-			return err
-		}
-		if err := canWriteProblem(actor, p); err != nil {
-			return err
-		}
-		version, err := repo.NextProblemStatementVersion(ctx, problemID)
-		if err != nil {
-			return err
-		}
-		if input.MakeCurrent {
-			if err := repo.ClearCurrentProblemStatement(ctx, problemID); err != nil {
-				return err
-			}
-		}
-		statement, err = repo.CreateProblemStatement(ctx, problemID, version, input)
-		if err != nil {
-			return err
-		}
-		return demotePublishedProblem(ctx, repo, p)
-	})
-	return statement, err
+	return s.authoring.CreateStatement(ctx, actor, problemID, input)
 }
 
 func (s *Service) CurrentStatement(ctx context.Context, actor auth.Actor, problemID int64) (Statement, error) {
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return Statement{}, err
-	}
-	if err := canReadProblem(actor, p); err != nil {
-		return Statement{}, err
-	}
-	return s.repo.GetCurrentProblemStatement(ctx, problemID)
+	return s.reader.CurrentStatement(ctx, actor, problemID)
 }
 
 func (s *Service) AssignTags(ctx context.Context, actor auth.Actor, problemID int64, input AssignTagsInput) ([]Tag, error) {
-	if err := validateTags(input.Tags); err != nil {
-		return nil, err
-	}
-	var tags []Tag
-	err := s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		p, err := repo.LockProblemForUpdate(ctx, problemID)
-		if err != nil {
-			return err
-		}
-		if err := canWriteProblem(actor, p); err != nil {
-			return err
-		}
-		tags, err = repo.ReplaceProblemTags(ctx, problemID, input.Tags)
-		return err
-	})
-	return tags, err
+	return s.authoring.AssignTags(ctx, actor, problemID, input)
 }
 
 func (s *Service) UploadTestcaseArchive(ctx context.Context, actor auth.Actor, problemID int64, input UploadTestcaseInput) (TestcaseSetRecord, error) {
-	if s.storage == nil {
-		return TestcaseSetRecord{}, apperror.ServiceUnavailable("object storage unavailable")
-	}
-	if err := validateTestcaseArchive(input.Content, input.CaseCount, input.ChecksumSHA256, defaultMaxTestcaseArchiveBytes); err != nil {
-		return TestcaseSetRecord{}, err
-	}
-	current, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return TestcaseSetRecord{}, err
-	}
-	if err := canWriteProblem(actor, current); err != nil {
-		return TestcaseSetRecord{}, err
-	}
-
-	actualChecksum := sha256Hex(input.Content)
-	contentType := input.ContentType
-	if contentType == "" {
-		contentType = "application/zip"
-	}
-	key, err := testcaseArchiveKey(problemID, actualChecksum)
-	if err != nil {
-		return TestcaseSetRecord{}, err
-	}
-	if _, err := s.storage.Put(ctx, storage.Object{
-		Key:         key,
-		ContentType: contentType,
-		Size:        int64(len(input.Content)),
-		Metadata: map[string]string{
-			"problem-id": fmt.Sprint(problemID),
-			"sha256":     actualChecksum,
-		},
-		Body: bytes.NewReader(input.Content),
-	}); err != nil {
-		return TestcaseSetRecord{}, err
-	}
-
-	var created TestcaseSetRecord
-	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		p, err := repo.LockProblemForUpdate(ctx, problemID)
-		if err != nil {
-			return err
-		}
-		if err := canWriteProblem(actor, p); err != nil {
-			return err
-		}
-		version, err := repo.NextTestcaseSetVersion(ctx, problemID)
-		if err != nil {
-			return err
-		}
-		artifact, err := repo.CreateArtifact(ctx, ArtifactRecord{
-			OwnerType:      "testcase",
-			OwnerID:        problemID,
-			Kind:           "testcase_archive",
-			StorageKey:     key,
-			ChecksumSHA256: actualChecksum,
-			SizeBytes:      int64(len(input.Content)),
-			ContentType:    contentType,
-		})
-		if err != nil {
-			return err
-		}
-		if artifact.ID == 0 {
-			return apperror.Internal()
-		}
-		if err := repo.ClearCurrentTestcaseSet(ctx, problemID); err != nil {
-			return err
-		}
-		created, err = repo.CreateTestcaseSet(ctx, problemID, version, key, actualChecksum, int64(len(input.Content)), input.CaseCount, actor.UserID)
-		if err != nil {
-			return err
-		}
-		return demotePublishedProblem(ctx, repo, p)
-	})
-	if err != nil {
-		_ = s.storage.Delete(ctx, key)
-	}
-	return created, err
+	return s.authoring.UploadTestcaseArchive(ctx, actor, problemID, input)
 }
 
 func (s *Service) RunProblemCheck(ctx context.Context, actor auth.Actor, problemID int64) (ProblemCheckResult, error) {
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-	if err := canWriteProblem(actor, p); err != nil {
-		return ProblemCheckResult{}, err
-	}
-
-	statement, err := s.repo.GetCurrentProblemStatement(ctx, problemID)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-	set, err := s.repo.GetCurrentReadyTestcaseSet(ctx, problemID)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-
-	findings := validateProblemCheckStatementSamples(statement)
-	storageReadable := false
-	zipReadable := false
-	caseCount := 0
-	if s.storage == nil {
-		findings = append(findings, problemCheckFindingDraft{
-			severity: ProblemCheckSeverityError,
-			code:     "testcase.storage_unreadable",
-			message:  "testcase object storage is unavailable",
-			details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
-		})
-	} else if strings.TrimSpace(set.StorageKey) == "" {
-		findings = append(findings, problemCheckFindingDraft{
-			severity: ProblemCheckSeverityError,
-			code:     "testcase.storage_unreadable",
-			message:  "testcase archive storage key is missing",
-		})
-	} else {
-		body, _, err := s.storage.Get(ctx, set.StorageKey)
-		if err != nil {
-			findings = append(findings, problemCheckFindingDraft{
-				severity: ProblemCheckSeverityError,
-				code:     "testcase.storage_unreadable",
-				message:  "testcase archive cannot be read from storage",
-				details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
-			})
-		} else {
-			storageReadable = true
-			data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
-			if err != nil {
-				if resourceErr, ok := err.(*testcaseArchiveResourceError); ok {
-					findings = append(findings, problemCheckFindingDraft{
-						severity: ProblemCheckSeverityError,
-						code:     resourceErr.code,
-						message:  resourceErr.message,
-						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
-					})
-				} else {
-					storageReadable = false
-					findings = append(findings, problemCheckFindingDraft{
-						severity: ProblemCheckSeverityError,
-						code:     "testcase.storage_unreadable",
-						message:  "testcase archive cannot be read from storage",
-						details:  problemCheckDetails(map[string]any{"storage_key": set.StorageKey}),
-					})
-				}
-			} else {
-				archiveResult := validateProblemCheckArchive(data, set)
-				zipReadable = archiveResult.zipReadable
-				caseCount = archiveResult.caseCount
-				findings = append(findings, archiveResult.findings...)
-			}
-		}
-	}
-
-	summary := problemCheckSummary(set.CaseCount, caseCount, storageReadable, zipReadable, findings)
-	summaryJSON, err := marshalProblemCheckSummary(summary)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-
-	var runRecord ProblemCheckRunRecord
-	persistedFindings := make([]ProblemCheckFinding, 0, len(findings))
-	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		run, err := repo.CreateProblemCheckRun(ctx, CreateProblemCheckRunInput{
-			ProblemID:     problemID,
-			StatementID:   statement.ID,
-			TestcaseSetID: set.ID,
-			RequestedBy:   actor.UserID,
-			Status:        ProblemCheckStatusRunning,
-			Summary:       json.RawMessage(`{}`),
-		})
-		if err != nil {
-			return err
-		}
-		for _, finding := range findings {
-			record, err := repo.CreateProblemCheckFinding(ctx, CreateProblemCheckFindingInput{
-				RunID:       run.ID,
-				Severity:    finding.severity,
-				Code:        finding.code,
-				Message:     finding.message,
-				CaseIndex:   finding.caseIndex,
-				TestcaseKey: finding.testcaseKey,
-				Details:     finding.details,
-			})
-			if err != nil {
-				return err
-			}
-			persistedFindings = append(persistedFindings, serviceProblemCheckFindingFromRecord(record))
-		}
-		runRecord, err = repo.CompleteProblemCheckRun(ctx, CompleteProblemCheckRunInput{
-			ID:         run.ID,
-			Summary:    summaryJSON,
-			FinishedAt: s.now(),
-		})
-		return err
-	})
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-	return ProblemCheckResult{Run: serviceProblemCheckRunFromRecord(runRecord), Findings: persistedFindings}, nil
+	return s.checks.RunProblemCheck(ctx, actor, problemID)
 }
 
 func (s *Service) GetProblemCheck(ctx context.Context, actor auth.Actor, problemID int64, checkID int64) (ProblemCheckResult, error) {
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-	if err := canWriteProblem(actor, p); err != nil {
-		return ProblemCheckResult{}, err
-	}
-	run, err := s.repo.GetProblemCheckRun(ctx, checkID)
-	if err != nil {
-		return ProblemCheckResult{}, problemCheckNotFoundErr(err)
-	}
-	if run.ProblemID != problemID {
-		return ProblemCheckResult{}, apperror.NotFound("problem_check.not_found", "problem check not found")
-	}
-	records, err := s.repo.ListProblemCheckFindings(ctx, checkID)
-	if err != nil {
-		return ProblemCheckResult{}, err
-	}
-	findings := make([]ProblemCheckFinding, 0, len(records))
-	for _, record := range records {
-		findings = append(findings, serviceProblemCheckFindingFromRecord(record))
-	}
-	return ProblemCheckResult{Run: serviceProblemCheckRunFromRecord(run), Findings: findings}, nil
+	return s.checks.GetProblemCheck(ctx, actor, problemID, checkID)
 }
 
 func (s *Service) ProblemResponse(ctx context.Context, p ProblemRecord) (ProblemResponse, error) {
-	tags, err := s.repo.ListProblemTags(ctx, p.ID)
-	if err != nil {
-		return ProblemResponse{}, err
-	}
-	tagNames := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		tagNames = append(tagNames, tag.Name)
-	}
-	return ProblemResponse{
-		ID:         p.ID,
-		Title:      p.Title,
-		Slug:       p.Slug,
-		Difficulty: p.Difficulty,
-		Visibility: p.Visibility,
-		Status:     p.Status,
-		Tags:       tagNames,
-		Limits: ProblemLimits{
-			TimeLimitMS:   p.TimeLimitMS,
-			MemoryLimitKB: p.MemoryLimitKB,
-		},
-		OwnerUserID: p.OwnerUserID,
-		CreatedAt:   p.CreatedAt,
-		UpdatedAt:   p.UpdatedAt,
-		PublishedAt: p.PublishedAt,
-	}, nil
+	return s.reader.ProblemResponse(ctx, p)
 }
 
 func (s *Service) CurrentReadyTestcaseSet(ctx context.Context, problemID int64) (TestcaseSet, error) {
-	set, err := s.repo.GetCurrentReadyTestcaseSet(ctx, problemID)
-	if err != nil {
-		return TestcaseSet{}, err
-	}
-	if s.storage == nil {
-		return TestcaseSet{}, apperror.ServiceUnavailable("testcase object storage unavailable")
-	}
-	if strings.TrimSpace(set.StorageKey) == "" {
-		return TestcaseSet{}, apperror.BadRequest("testcase.archive_missing", "testcase archive storage key is missing")
-	}
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return TestcaseSet{}, err
-	}
-	body, _, err := s.storage.Get(ctx, set.StorageKey)
-	if err != nil {
-		return TestcaseSet{}, err
-	}
-	data, err := readAllAndClose(body, defaultMaxTestcaseArchiveBytes)
-	if err != nil {
-		if _, ok := err.(*testcaseArchiveResourceError); ok {
-			return TestcaseSet{}, testcaseArchiveBadRequest(err)
-		}
-		return TestcaseSet{}, err
-	}
-	cases, err := parseTestcaseArchiveCases(data, time.Duration(p.TimeLimitMS)*time.Millisecond, int64(p.MemoryLimitKB))
-	if err != nil {
-		return TestcaseSet{}, err
-	}
-	if set.CaseCount > 0 && int32(len(cases)) != set.CaseCount {
-		return TestcaseSet{}, apperror.BadRequest("testcase.case_count_mismatch", "case_count does not match input/output pairs")
-	}
-	return TestcaseSet{
-		ID:        set.ID,
-		ProblemID: set.ProblemID,
-		Version:   int(set.Version),
-		Status:    set.Status,
-		Cases:     cases,
-	}, nil
+	return s.reader.CurrentReadyTestcaseSet(ctx, problemID)
 }
 
 func (s *Service) GetForJudge(ctx context.Context, problemID int64) (Problem, error) {
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return Problem{}, err
-	}
-	if p.Status != StatusPublished || p.CurrentStatementID == 0 || p.CurrentTestcaseSetID == 0 || p.CurrentTestcaseStatus != TestcaseStatusReady {
-		return Problem{}, apperror.NotFound("problem.not_ready", "problem is not ready for judge")
-	}
-	return Problem{
-		ID:                   p.ID,
-		Slug:                 p.Slug,
-		Title:                p.Title,
-		Visibility:           p.Visibility,
-		OwnerUserID:          p.OwnerUserID,
-		CurrentStatementID:   p.CurrentStatementID,
-		CurrentTestcaseSetID: p.CurrentTestcaseSetID,
-	}, nil
+	return s.reader.GetForJudge(ctx, problemID)
 }
 
 func (s *Service) AuthorizeProblemRejudge(ctx context.Context, actor auth.Actor, id int64) error {
-	problem, err := s.repo.GetProblem(ctx, id)
-	if err != nil {
-		return err
-	}
-	return canWriteProblem(actor, problem)
+	return s.reader.AuthorizeProblemRejudge(ctx, actor, id)
 }
 
 func (s *Service) Stats(ctx context.Context, actor auth.Actor, problemID int64) (ProblemStats, error) {
-	p, err := s.repo.GetProblem(ctx, problemID)
-	if err != nil {
-		return ProblemStats{}, err
-	}
-	if err := canReadProblem(actor, p); err != nil {
-		return ProblemStats{}, err
-	}
-	stats, err := s.repo.GetProblemStats(ctx, problemID)
-	if err != nil {
-		return ProblemStats{}, err
-	}
-	if stats.TotalSubmissions > 0 {
-		stats.AcceptanceRate = float64(stats.AcceptedSubmissions) / float64(stats.TotalSubmissions)
-	}
-	return stats, nil
-}
-
-func ensurePublishable(ctx context.Context, repo Repository, problemID int64) error {
-	readiness, err := loadProblemAuthoringReadiness(ctx, repo, problemID)
-	if err != nil {
-		return err
-	}
-	if len(readiness.blockers) > 0 {
-		blocker := readiness.blockers[0]
-		return apperror.Unprocessable(blocker.Code, blocker.Message)
-	}
-	return nil
-}
-
-func demotePublishedProblem(ctx context.Context, repo Repository, problem ProblemRecord) error {
-	if problem.Status != StatusPublished {
-		return nil
-	}
-	status := StatusDraft
-	_, err := repo.UpdateProblem(ctx, problem.ID, UpdateProblemInput{Status: &status})
-	return err
-}
-
-type problemAuthoringReadiness struct {
-	statement   *Statement
-	testcaseSet *TestcaseSetRecord
-	latestCheck *ProblemCheckRun
-	blockers    []ProblemAuthoringBlocker
-}
-
-func loadProblemAuthoringReadiness(ctx context.Context, repo Repository, problemID int64) (problemAuthoringReadiness, error) {
-	state := problemAuthoringReadiness{blockers: []ProblemAuthoringBlocker{}}
-	statement, err := repo.GetCurrentProblemStatement(ctx, problemID)
-	if err != nil {
-		if !isNotFoundError(err) {
-			return problemAuthoringReadiness{}, err
-		}
-		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.statement_required", Message: "current statement is required before publishing"})
-	} else {
-		state.statement = &statement
-	}
-
-	testcaseSet, err := repo.GetCurrentReadyTestcaseSet(ctx, problemID)
-	if err != nil {
-		if !isNotFoundError(err) {
-			return problemAuthoringReadiness{}, err
-		}
-		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.testcase_required", Message: "current ready testcase set is required before publishing"})
-		return state, nil
-	}
-	state.testcaseSet = &testcaseSet
-
-	if state.statement == nil {
-		return state, nil
-	}
-	runRecord, err := repo.GetLatestCompletedProblemCheckRun(ctx, problemID, state.statement.ID, testcaseSet.ID)
-	if err != nil {
-		if !isNotFoundError(err) {
-			return problemAuthoringReadiness{}, err
-		}
-		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_required", Message: "run a problem check for the current testcase set before publishing"})
-		return state, nil
-	}
-	run := problemCheckRunFromRecord(runRecord)
-	findings, err := repo.ListProblemCheckFindings(ctx, run.ID)
-	if err != nil {
-		return problemAuthoringReadiness{}, err
-	}
-	run.Findings = make([]ProblemCheckFinding, 0, len(findings))
-	for _, finding := range findings {
-		run.Findings = append(run.Findings, problemCheckFindingFromRecord(finding))
-	}
-	state.latestCheck = &run
-	if !run.Summary.Valid {
-		state.blockers = append(state.blockers, ProblemAuthoringBlocker{Code: "problem.check_failed", Message: "the current testcase set has validation errors"})
-	}
-	return state, nil
-}
-
-func isNotFoundError(err error) bool {
-	appErr, ok := apperror.From(err)
-	return ok && appErr.HTTPStatus == http.StatusNotFound
+	return s.reader.Stats(ctx, actor, problemID)
 }
 
 type problemCheckFindingDraft struct {
@@ -1181,45 +596,6 @@ func problemCheckDetails(value map[string]any) json.RawMessage {
 		return json.RawMessage(`{}`)
 	}
 	return json.RawMessage(data)
-}
-
-func serviceProblemCheckRunFromRecord(record ProblemCheckRunRecord) ProblemCheckRun {
-	summary := ProblemCheckSummary{}
-	if len(record.Summary) > 0 {
-		_ = json.Unmarshal(record.Summary, &summary)
-	}
-	return ProblemCheckRun{
-		ID:            record.ID,
-		ProblemID:     record.ProblemID,
-		StatementID:   record.StatementID,
-		TestcaseSetID: record.TestcaseSetID,
-		RequestedBy:   record.RequestedBy,
-		Status:        record.Status,
-		Summary:       summary,
-		ErrorMessage:  record.ErrorMessage,
-		StartedAt:     record.StartedAt,
-		FinishedAt:    record.FinishedAt,
-		CreatedAt:     record.CreatedAt,
-		UpdatedAt:     record.UpdatedAt,
-	}
-}
-
-func serviceProblemCheckFindingFromRecord(record ProblemCheckFindingRecord) ProblemCheckFinding {
-	details := record.Details
-	if len(details) == 0 {
-		details = json.RawMessage(`{}`)
-	}
-	return ProblemCheckFinding{
-		ID:          record.ID,
-		RunID:       record.RunID,
-		Severity:    record.Severity,
-		Code:        record.Code,
-		Message:     record.Message,
-		CaseIndex:   record.CaseIndex,
-		TestcaseKey: record.TestcaseKey,
-		Details:     details,
-		CreatedAt:   record.CreatedAt,
-	}
 }
 
 func problemCheckNotFoundErr(err error) error {

--- a/internal/problem/service_test.go
+++ b/internal/problem/service_test.go
@@ -22,7 +22,7 @@ func TestProblemAuthorizationAllowsOwnerAndAdmin(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
 	store := &fakeStorage{}
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 	title := "Updated"
 
 	_, err := service.UpdateProblem(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1, UpdateProblemInput{Title: &title})
@@ -36,10 +36,24 @@ func TestProblemAuthorizationAllowsOwnerAndAdmin(t *testing.T) {
 	}
 }
 
+func newProblemService(repo *fakeRepository, objectStore *fakeStorage) *Service {
+	var readerArchives testcaseArchiveReader
+	var authoringArchives testcaseArchiveWriter
+	if objectStore != nil {
+		readerArchives = objectStore
+		authoringArchives = objectStore
+	}
+	return NewService(
+		NewProblemReader(repo, readerArchives),
+		NewProblemAuthoring(repo, authoringArchives),
+		NewProblemCheckService(repo, readerArchives, time.Now),
+	)
+}
+
 func TestAuthorizeProblemRejudgeUsesProblemOwnership(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusPublished, Visibility: VisibilityPublic}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	if err := service.AuthorizeProblemRejudge(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1); err != nil {
 		t.Fatalf("owner authorization returned error: %v", err)
@@ -83,7 +97,7 @@ func TestPublishRequiresValidCheckForCurrentTestcaseSet(t *testing.T) {
 			if tt.seedRun != nil {
 				repo.checkRuns[tt.seedRun.ID] = *tt.seedRun
 			}
-			service := NewService(repo, &fakeStorage{})
+			service := newProblemService(repo, &fakeStorage{})
 			status := StatusPublished
 
 			_, err := service.UpdateProblem(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UpdateProblemInput{Status: &status})
@@ -100,7 +114,7 @@ func TestPublishAllowsValidCheckForCurrentTestcaseSet(t *testing.T) {
 		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
 		Summary: json.RawMessage(`{"valid":true,"error_count":0}`),
 	}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	status := StatusPublished
 
 	updated, err := service.UpdateProblem(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UpdateProblemInput{Status: &status})
@@ -122,7 +136,7 @@ func TestSavingNewStatementInvalidatesPreviousValidCheck(t *testing.T) {
 		Summary: json.RawMessage(`{"valid":true,"error_count":0}`),
 	}
 	store := &fakeStorage{}
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 	actor := auth.Actor{UserID: 10, Role: auth.RoleUser}
 
 	statement, err := service.CreateStatement(t.Context(), actor, 1, CreateStatementInput{
@@ -176,7 +190,7 @@ func TestSavingNewStatementInvalidatesPreviousValidCheck(t *testing.T) {
 func TestProblemAuthoringStateReportsPublishBlockers(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	state, err := service.GetProblemAuthoringState(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
 
@@ -198,7 +212,7 @@ func TestProblemAuthoringStateReturnsCurrentValidCheck(t *testing.T) {
 		ID: 1, ProblemID: 1, StatementID: 3, TestcaseSetID: 7, Status: ProblemCheckStatusCompleted,
 		Summary: json.RawMessage(`{"valid":true}`),
 	}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	state, err := service.GetProblemAuthoringState(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
 
@@ -215,7 +229,7 @@ func TestProblemAuthoringStateReturnsCurrentValidCheck(t *testing.T) {
 
 func TestListProblemsMineRequiresAuthentication(t *testing.T) {
 	repo := newFakeRepository()
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	_, err := service.ListProblems(t.Context(), auth.Actor{}, ListProblemsFilter{Mine: true})
 
@@ -235,7 +249,7 @@ func TestListProblemsByCursorReturnsNextCursor(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[2] = ProblemRecord{ID: 2, Title: "Second", Slug: "second", Status: StatusPublished, Visibility: VisibilityPublic, CreatedAt: now.Add(-time.Minute)}
 	repo.problems[1] = ProblemRecord{ID: 1, Title: "First", Slug: "first", Status: StatusPublished, Visibility: VisibilityPublic, CreatedAt: now.Add(-2 * time.Minute)}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	page, err := service.ListProblemsByCursor(context.Background(), auth.Anonymous("req"), ListProblemsFilter{PageSize: 1})
 	if err != nil {
@@ -260,7 +274,7 @@ func TestListProblemsByCursorReturnsNextCursor(t *testing.T) {
 func TestCreateStatementSwitchesCurrentVersion(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	actor := auth.Actor{UserID: 10, Role: auth.RoleUser}
 
 	first, err := service.CreateStatement(context.Background(), actor, 1, CreateStatementInput{Title: "A", Description: "desc"})
@@ -286,7 +300,7 @@ func TestCreateStatementSwitchesCurrentVersion(t *testing.T) {
 func TestCreateStatementDemotesPublishedProblemToDraft(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusPublished, Visibility: VisibilityPublic}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 
 	_, err := service.CreateStatement(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, CreateStatementInput{Title: "Updated", Description: "desc"})
 
@@ -302,7 +316,7 @@ func TestUploadTestcaseArchiveValidationFailure(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
 	store := &fakeStorage{}
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 
 	archive := zipArchive(t, map[string]string{"input1.txt": "1\n", "output1.txt": "1\n"})
 	_, err := service.UploadTestcaseArchive(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UploadTestcaseInput{
@@ -319,7 +333,7 @@ func TestUploadTestcaseArchiveValidationFailure(t *testing.T) {
 func TestUploadTestcaseArchiveRejectsIllegalFileName(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	archive := zipArchive(t, map[string]string{
 		"input1.txt":  "1\n",
 		"output1.txt": "1\n",
@@ -340,7 +354,7 @@ func TestUploadTestcaseArchiveDeletesObjectWhenTransactionFails(t *testing.T) {
 	repo.failCreateTestcaseSet = true
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
 	store := &fakeStorage{}
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 	archive := zipArchive(t, map[string]string{"input1.txt": "1\n", "output1.txt": "1\n"})
 
 	_, err := service.UploadTestcaseArchive(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UploadTestcaseInput{
@@ -359,7 +373,7 @@ func TestUploadTestcaseArchiveDeletesObjectWhenTransactionFails(t *testing.T) {
 func TestUploadTestcaseArchiveDemotesPublishedProblemToDraft(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusPublished, Visibility: VisibilityPublic}
-	service := NewService(repo, &fakeStorage{})
+	service := newProblemService(repo, &fakeStorage{})
 	archive := zipArchive(t, map[string]string{"input1.txt": "1\n", "output1.txt": "1\n"})
 
 	_, err := service.UploadTestcaseArchive(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, UploadTestcaseInput{Content: archive, CaseCount: 1, ChecksumSHA256: sha256Hex(archive)})
@@ -401,7 +415,7 @@ func TestCurrentReadyTestcaseSetLoadsCasesFromArchive(t *testing.T) {
 	store := &fakeStorage{objects: map[string][]byte{"cases.zip": archive}}
 	repo.testcaseSets[7] = TestcaseSetRecord{ID: 7, ProblemID: 1, Version: 3, StorageKey: "cases.zip", CaseCount: 2, Status: TestcaseStatusReady, IsCurrent: true}
 	repo.currentTestcase[1] = 7
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 
 	got, err := service.CurrentReadyTestcaseSet(context.Background(), 1)
 	if err != nil {
@@ -425,7 +439,7 @@ func TestCurrentReadyTestcaseSetRequiresStorage(t *testing.T) {
 	repo := newFakeRepository()
 	repo.testcaseSets[7] = TestcaseSetRecord{ID: 7, ProblemID: 1, Version: 3, StorageKey: "cases.zip", CaseCount: 1, Status: TestcaseStatusReady, IsCurrent: true}
 	repo.currentTestcase[1] = 7
-	service := NewService(repo, nil)
+	service := newProblemService(repo, nil)
 
 	_, err := service.CurrentReadyTestcaseSet(context.Background(), 1)
 	assertAppCode(t, err, "service_unavailable")
@@ -435,7 +449,7 @@ func TestConcurrentUploadSerializesVersionAllocation(t *testing.T) {
 	repo := newFakeRepository()
 	repo.problems[1] = ProblemRecord{ID: 1, OwnerUserID: 10, Status: StatusDraft, Visibility: VisibilityPrivate}
 	store := &fakeStorage{delay: 20 * time.Millisecond}
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 	archive := zipArchive(t, map[string]string{"input1.txt": "1\n", "output1.txt": "1\n"})
 	actor := auth.Actor{UserID: 10, Role: auth.RoleUser}
 
@@ -480,7 +494,7 @@ func TestRunProblemCheckRequiresOwnerOrAdmin(t *testing.T) {
 		"input1.txt":  "1\n",
 		"output1.txt": "1\n",
 	}), 1)
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 
 	_, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1)
 	assertAppCode(t, err, "problem.forbidden")
@@ -502,8 +516,8 @@ func TestRunProblemCheckPersistsCompletedRunAndSummary(t *testing.T) {
 		"input2.txt":  "2 3\n",
 		"output2.txt": "5\n",
 	}), 2)
-	service := NewService(repo, store)
-	service.now = func() time.Time { return time.Unix(100, 0).UTC() }
+	service := newProblemService(repo, store)
+	service.checks.now = func() time.Time { return time.Unix(100, 0).UTC() }
 
 	result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
 	if err != nil {
@@ -580,7 +594,7 @@ func TestRunProblemCheckReportsArchiveFindings(t *testing.T) {
 			repo := newFakeRepository()
 			store := &fakeStorage{}
 			seedProblemCheckData(t, repo, store, `[]`, tt.archive, tt.caseCount)
-			service := NewService(repo, store)
+			service := newProblemService(repo, store)
 
 			result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
 			if err != nil {
@@ -621,7 +635,7 @@ func TestRunProblemCheckReportsStatementSampleJSONFindings(t *testing.T) {
 				"input1.txt":  "1\n",
 				"output1.txt": "1\n",
 			}), 1)
-			service := NewService(repo, store)
+			service := newProblemService(repo, store)
 
 			result, err := service.RunProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1)
 			if err != nil {
@@ -640,7 +654,7 @@ func TestGetProblemCheckReturnsCheckNotFoundForMissingRun(t *testing.T) {
 		"input1.txt":  "1\n",
 		"output1.txt": "1\n",
 	}), 1)
-	service := NewService(repo, store)
+	service := newProblemService(repo, store)
 
 	_, err := service.GetProblemCheck(context.Background(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1, 99)
 
@@ -728,7 +742,13 @@ func newFakeRepository() *fakeRepository {
 	}
 }
 
-func (r *fakeRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
+func (r *fakeRepository) WithProblemAuthoringTx(ctx context.Context, fn func(context.Context, problemAuthoringTx) error) error {
+	r.txMu.Lock()
+	defer r.txMu.Unlock()
+	return fn(ctx, r)
+}
+
+func (r *fakeRepository) WithProblemCheckTx(ctx context.Context, fn func(context.Context, problemCheckTx) error) error {
 	r.txMu.Lock()
 	defer r.txMu.Unlock()
 	return fn(ctx, r)
@@ -1043,36 +1063,6 @@ func (r *fakeRepository) GetLatestCompletedProblemCheckRun(ctx context.Context, 
 	return latest, nil
 }
 
-func (r *fakeRepository) ListProblemCheckRuns(ctx context.Context, filter ListProblemCheckRunsFilter) ([]ProblemCheckRunRecord, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	runs := make([]ProblemCheckRunRecord, 0)
-	for _, run := range r.checkRuns {
-		if run.ProblemID == filter.ProblemID {
-			runs = append(runs, run)
-		}
-	}
-	sort.Slice(runs, func(i, j int) bool {
-		if runs[i].CreatedAt.Equal(runs[j].CreatedAt) {
-			return runs[i].ID > runs[j].ID
-		}
-		return runs[i].CreatedAt.After(runs[j].CreatedAt)
-	})
-	if filter.Offset >= int32(len(runs)) {
-		return nil, nil
-	}
-	start := int(filter.Offset)
-	end := start + int(filter.Limit)
-	if filter.Limit <= 0 {
-		end = start
-	}
-	if end > len(runs) {
-		end = len(runs)
-	}
-	return append([]ProblemCheckRunRecord(nil), runs[start:end]...), nil
-}
-
 func (r *fakeRepository) CompleteProblemCheckRun(ctx context.Context, input CompleteProblemCheckRunInput) (ProblemCheckRunRecord, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -1089,28 +1079,6 @@ func (r *fakeRepository) CompleteProblemCheckRun(ctx context.Context, input Comp
 	run.Status = ProblemCheckStatusCompleted
 	run.Summary = jsonRawFromDB(input.Summary)
 	run.ErrorMessage = ""
-	run.FinishedAt = finishedAt
-	run.UpdatedAt = now
-	r.checkRuns[run.ID] = run
-	return run, nil
-}
-
-func (r *fakeRepository) FailProblemCheckRun(ctx context.Context, input FailProblemCheckRunInput) (ProblemCheckRunRecord, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	run, ok := r.checkRuns[input.ID]
-	if !ok || (run.Status != ProblemCheckStatusQueued && run.Status != ProblemCheckStatusRunning) {
-		return ProblemCheckRunRecord{}, apperror.NotFound("problem.not_found", "problem not found")
-	}
-	now := time.Now()
-	finishedAt := input.FinishedAt
-	if finishedAt.IsZero() {
-		finishedAt = now
-	}
-	run.Status = ProblemCheckStatusFailed
-	run.Summary = jsonRawFromDB(input.Summary)
-	run.ErrorMessage = input.ErrorMessage
 	run.FinishedAt = finishedAt
 	run.UpdatedAt = now
 	r.checkRuns[run.ID] = run
@@ -1135,20 +1103,6 @@ func (r *fakeRepository) CreateProblemCheckFinding(ctx context.Context, input Cr
 	}
 	r.checkFindings[finding.RunID] = append(r.checkFindings[finding.RunID], finding)
 	return finding, nil
-}
-
-func (r *fakeRepository) GetProblemCheckFinding(ctx context.Context, id int64) (ProblemCheckFindingRecord, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	for _, findings := range r.checkFindings {
-		for _, finding := range findings {
-			if finding.ID == id {
-				return finding, nil
-			}
-		}
-	}
-	return ProblemCheckFindingRecord{}, apperror.NotFound("problem.not_found", "problem not found")
 }
 
 func (r *fakeRepository) ListProblemCheckFindings(ctx context.Context, runID int64) ([]ProblemCheckFindingRecord, error) {


### PR DESCRIPTION
## 概述

- 将题目域拆为 `ProblemReader`、`ProblemAuthoring` 和 `ProblemCheckService` 三个具体协作者。
- 删除全量 `problem.Repository` 与旧构造器，改由消费者在本地声明最小未导出端口。
- 保持编写事务内的锁定、版本分配、当前记录切换和发布就绪度校验；worker 仅注入读取协作者。

## 设计

- 读取协作者负责目录、详情、编写状态、判题读取、重判授权和统计。
- 编写协作者只依赖原子写入事务及归档写端口；检查协作者只依赖检查事务及归档读端口。
- `Service` 保留 HTTP 对外门面，构造时拒绝缺失的必需协作者，避免半初始化实例。

## 验证

- `go test -count=1 -race ./internal/problem`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -count=1 ./...`

Closes #57
Related to #43

## 进度记录

- 2026-07-25：完成读、编写、检查工作流端口拆分，移除未使用的高层仓储包装，并完成本地验证。
- 2026-07-25：GitHub Actions 的 Backend 与 Docker Smoke 均已通过。