### PR TITLE
perf(submission): move testcase loading out of judge queue

### DIFF
--- a/docs/v2-deploy.md
+++ b/docs/v2-deploy.md
@@ -26,7 +26,7 @@ This mode runs real Go/C++ toolchains in the judge-agent container, but it is no
 
 ## Judge Event Flow
 
-The worker process has two production loops: a dispatcher that claims `judge_tasks` and publishes `judge.request.v1` to `SOJ_REDIS_STREAM`, and a result consumer that reads `judge.result.v1` from `SOJ_JUDGE_RESULT_STREAM`. The result consumer acknowledges Redis only after the PostgreSQL transaction updates `judge_attempts`, `submission_results`, `judge_tasks`, and contest projections.
+The worker process has two production loops: a dispatcher that claims `judge_tasks` and publishes `judge.request.v2` references to `SOJ_REDIS_STREAM`, and a result consumer that reads `judge.result.v1` from `SOJ_JUDGE_RESULT_STREAM`. The result consumer acknowledges Redis only after the PostgreSQL transaction updates `judge_attempts`, `submission_results`, `judge_tasks`, and contest projections.
 
 `soj-judge-agent` consumes requests from `SOJ_JUDGE_REQUEST_STREAM` and publishes results to `SOJ_JUDGE_RESULT_STREAM`. The agent does not receive business database credentials. The result consumer group is created from Redis stream ID `0` so already-published result events are not skipped during first startup or recovery.
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.52.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -69,7 +70,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -80,15 +80,13 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 	contestRepo := contest.NewPostgresRepository(pool)
 	contestService := contest.NewService(contestRepo)
 	submissionRepo := submission.NewSQLRepositoryWithTxRunner(queries, pool)
-	testcaseResolver := submission.NewTestcaseSnapshotResolver(queries, objectStorage)
 	judgeEngine := newJudgeEngine(cfg.Judge)
 	sourceStore := submission.NewObjectSourceStore(objectStorage)
 	creator := submission.NewSubmissionCreator(submission.SubmissionCreatorOptions{
-		Store:            submissionRepo,
-		ProblemReader:    problemReader,
-		TestcaseResolver: testcaseResolver,
-		SourceStore:      sourceStore,
-		ContestPolicy:    contestService,
+		Store:         submissionRepo,
+		ProblemReader: problemReader,
+		SourceStore:   sourceStore,
+		ContestPolicy: contestService,
 	})
 	reader := submission.NewSubmissionReader(submissionRepo, contestService)
 	runs := submission.NewRunService(submission.RunServiceOptions{

--- a/internal/app/judge_agent.go
+++ b/internal/app/judge_agent.go
@@ -252,7 +252,7 @@ func judgeAgentMessageLanguageKey(message queue.Message) string {
 	return ""
 }
 
-func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Config, objectStore storage.ObjectStorage, observer sandbox.SandboxObserver, logger *slog.Logger, publisher submission.ResultPublisher) (judgeRequestProcessor, observability.CheckFunc, error) {
+func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Config, objectStore storage.ObjectStorage, metrics *observability.Metrics, logger *slog.Logger, publisher submission.ResultPublisher) (judgeRequestProcessor, observability.CheckFunc, error) {
 	sourceStore := submission.NewObjectSourceStore(objectStore)
 	if backend == sandbox.BackendFake {
 		return submission.NewFakeAsyncAgent(submission.FakeAsyncAgentOptions{
@@ -261,7 +261,7 @@ func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Conf
 			ResultPublisher: publisher,
 		}), nil, nil
 	}
-	runtimeSandbox, err := newJudgeAgentSandbox(backend, cfg.Judge.CleanupTimeout, observer, logger)
+	runtimeSandbox, err := newJudgeAgentSandbox(backend, cfg.Judge.CleanupTimeout, metrics, logger)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -279,9 +279,11 @@ func newJudgeAgentProcessor(ctx context.Context, backend string, cfg config.Conf
 		}
 		return sandbox.ValidateProductionCapabilities(cfg.Env, capabilities)
 	}
+	testcaseCache := submission.NewTestcaseCache(objectStore, submission.TestcaseCacheOptions{Metrics: metrics})
 	return submission.NewCoreAsyncAgent(submission.CoreAsyncAgentOptions{
 		Core:            judgecore.New(judgecore.Options{Sandbox: runtimeSandbox, CleanupTimeout: cfg.Judge.CleanupTimeout}),
 		SourceStore:     sourceStore,
+		TestcaseLoader:  testcaseCache,
 		ResultPublisher: publisher,
 	}), sandboxReady, nil
 }

--- a/internal/judge/events/events.go
+++ b/internal/judge/events/events.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	RequestEventType    = "judge.request.v1"
+	RequestEventType    = "judge.request.v2"
 	ProgressEventType   = "judge.progress.v1"
 	ResultEventType     = "judge.result.v1"
 	DeadLetterEventType = "judge.dead_letter.v1"
@@ -21,18 +21,12 @@ type ArtifactRef struct {
 }
 
 type TestcaseSetRef struct {
-	ID   int64  `json:"id"`
-	Hash string `json:"hash"`
-}
-
-type TestcaseRef struct {
-	Index             int    `json:"index"`
-	GroupName         string `json:"group_name,omitempty"`
-	InputKey          string `json:"input_key"`
-	ExpectedOutputKey string `json:"expected_output_key"`
-	TimeLimitMS       int64  `json:"time_limit_ms,omitempty"`
-	MemoryKB          int64  `json:"memory_kb,omitempty"`
-	Score             int32  `json:"score,omitempty"`
+	ID             int64  `json:"id"`
+	ChecksumSHA256 string `json:"checksum_sha256"`
+	StorageKey     string `json:"storage_key"`
+	CaseCount      int32  `json:"case_count"`
+	TimeLimitMS    int64  `json:"time_limit_ms,omitempty"`
+	MemoryKB       int64  `json:"memory_kb,omitempty"`
 }
 
 type TraceContext struct {
@@ -56,7 +50,6 @@ type RequestEvent struct {
 	LanguageSlug    string         `json:"language_slug,omitempty"`
 	SourceArtifact  ArtifactRef    `json:"source_artifact"`
 	TestcaseSet     TestcaseSetRef `json:"testcase_set"`
-	Testcases       []TestcaseRef  `json:"testcases,omitempty"`
 	TimeoutMS       int64          `json:"timeout_ms,omitempty"`
 	MemoryKB        int64          `json:"memory_kb,omitempty"`
 	Priority        string         `json:"priority,omitempty"`
@@ -94,8 +87,14 @@ func (e RequestEvent) Validate() error {
 	if e.TestcaseSet.ID == 0 {
 		return fmt.Errorf("testcase_set.id is required")
 	}
-	if e.TestcaseSet.Hash == "" {
-		return fmt.Errorf("testcase_set.hash is required")
+	if e.TestcaseSet.ChecksumSHA256 == "" {
+		return fmt.Errorf("testcase_set.checksum_sha256 is required")
+	}
+	if e.TestcaseSet.StorageKey == "" {
+		return fmt.Errorf("testcase_set.storage_key is required")
+	}
+	if e.TestcaseSet.CaseCount <= 0 {
+		return fmt.Errorf("testcase_set.case_count must be positive")
 	}
 	return nil
 }

--- a/internal/judge/events/events_test.go
+++ b/internal/judge/events/events_test.go
@@ -18,7 +18,7 @@ func TestTraceContextSerializesSeparatelyFromTraceID(t *testing.T) {
 		SubmissionID:   7,
 		LanguageID:     71,
 		SourceArtifact: ArtifactRef{ID: 4, StorageKey: "source/key", ContentHash: "sha256:abc"},
-		TestcaseSet:    TestcaseSetRef{ID: 3, Hash: "cases-hash"},
+		TestcaseSet:    testTestcaseSetRef(),
 		CreatedAt:      time.Unix(100, 0).UTC(),
 	}
 	if err := event.Validate(); err != nil {
@@ -57,7 +57,7 @@ func TestRequestEventValidateAllowsAbsentOrMalformedTraceContext(t *testing.T) {
 		SubmissionID:   7,
 		LanguageID:     71,
 		SourceArtifact: ArtifactRef{ID: 4, StorageKey: "source/key", ContentHash: "sha256:abc"},
-		TestcaseSet:    TestcaseSetRef{ID: 3, Hash: "cases-hash"},
+		TestcaseSet:    testTestcaseSetRef(),
 		CreatedAt:      time.Unix(100, 0).UTC(),
 	}
 	if err := event.Validate(); err != nil {
@@ -78,7 +78,7 @@ func TestRequestEventValidateRequiresProductionIdentityAndArtifactRef(t *testing
 		SubmissionID:   7,
 		LanguageID:     71,
 		SourceArtifact: ArtifactRef{ID: 4, StorageKey: "source/key", ContentHash: "sha256:abc"},
-		TestcaseSet:    TestcaseSetRef{ID: 3, Hash: "cases-hash"},
+		TestcaseSet:    testTestcaseSetRef(),
 		TimeoutMS:      1000,
 		CreatedAt:      time.Unix(100, 0).UTC(),
 	}
@@ -97,6 +97,10 @@ func TestRequestEventValidateRequiresProductionIdentityAndArtifactRef(t *testing
 	if err := event.Validate(); err == nil || !strings.Contains(err.Error(), "source_artifact.content_hash") {
 		t.Fatalf("Validate error = %v, want source artifact content hash", err)
 	}
+}
+
+func testTestcaseSetRef() TestcaseSetRef {
+	return TestcaseSetRef{ID: 3, ChecksumSHA256: "cases-hash", StorageKey: "cases.zip", CaseCount: 1}
 }
 
 func TestResultProgressAndDeadLetterRequireRequestEventID(t *testing.T) {

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -16,6 +16,7 @@ type Metrics struct {
 	httpRequests           *prometheus.CounterVec
 	httpRequestDuration    *prometheus.HistogramVec
 	judgeDispatches        *prometheus.CounterVec
+	judgeRequestPayload    prometheus.Histogram
 	judgeTasks             *prometheus.CounterVec
 	judgeTaskDuration      *prometheus.HistogramVec
 	resultConsumer         *prometheus.CounterVec
@@ -25,6 +26,10 @@ type Metrics struct {
 	queueOldestPending     *prometheus.GaugeVec
 	judgeAgentSlotsUsed    *prometheus.GaugeVec
 	judgeAgentSlotsCap     *prometheus.GaugeVec
+	testcaseCache          *prometheus.CounterVec
+	testcaseCachePhase     *prometheus.HistogramVec
+	testcaseCacheBytes     prometheus.Gauge
+	testcaseCacheEvictions prometheus.Counter
 	sandboxPhaseDuration   *prometheus.HistogramVec
 	sandboxBackendErrors   *prometheus.CounterVec
 	sandboxCleanupFails    *prometheus.CounterVec
@@ -64,6 +69,14 @@ func NewMetrics(service string) *Metrics {
 			Help:        "Total number of judge task dispatch attempts.",
 			ConstLabels: labels,
 		}, []string{"result"}),
+		judgeRequestPayload: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace:   "soj",
+			Subsystem:   "worker",
+			Name:        "judge_request_payload_size_bytes",
+			Help:        "Judge request payload size in bytes.",
+			ConstLabels: labels,
+			Buckets:     []float64{512, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304},
+		}),
 		judgeTasks: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace:   "soj",
 			Subsystem:   "worker",
@@ -126,6 +139,35 @@ func NewMetrics(service string) *Metrics {
 			Help:        "Configured judge-agent sandbox slot capacity.",
 			ConstLabels: labels,
 		}, []string{"scope", "language"}),
+		testcaseCache: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace:   "soj",
+			Subsystem:   "judge_agent",
+			Name:        "testcase_cache_total",
+			Help:        "Testcase cache lookups by outcome.",
+			ConstLabels: labels,
+		}, []string{"result"}),
+		testcaseCachePhase: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:   "soj",
+			Subsystem:   "judge_agent",
+			Name:        "testcase_cache_phase_duration_seconds",
+			Help:        "Testcase cache download and unpack duration in seconds.",
+			ConstLabels: labels,
+			Buckets:     []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+		}, []string{"phase", "result"}),
+		testcaseCacheBytes: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   "soj",
+			Subsystem:   "judge_agent",
+			Name:        "testcase_cache_bytes",
+			Help:        "Current bytes held by the judge-agent testcase cache.",
+			ConstLabels: labels,
+		}),
+		testcaseCacheEvictions: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   "soj",
+			Subsystem:   "judge_agent",
+			Name:        "testcase_cache_evictions_total",
+			Help:        "Testcase cache entries evicted by the judge agent.",
+			ConstLabels: labels,
+		}),
 		sandboxPhaseDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace:   "soj",
 			Subsystem:   "sandbox",
@@ -197,6 +239,7 @@ func NewMetrics(service string) *Metrics {
 		metrics.httpRequests,
 		metrics.httpRequestDuration,
 		metrics.judgeDispatches,
+		metrics.judgeRequestPayload,
 		metrics.judgeTasks,
 		metrics.judgeTaskDuration,
 		metrics.resultConsumer,
@@ -206,6 +249,10 @@ func NewMetrics(service string) *Metrics {
 		metrics.queueOldestPending,
 		metrics.judgeAgentSlotsUsed,
 		metrics.judgeAgentSlotsCap,
+		metrics.testcaseCache,
+		metrics.testcaseCachePhase,
+		metrics.testcaseCacheBytes,
+		metrics.testcaseCacheEvictions,
 		metrics.sandboxPhaseDuration,
 		metrics.sandboxBackendErrors,
 		metrics.sandboxCleanupFails,
@@ -231,6 +278,37 @@ func (m *Metrics) ObserveHTTPRequest(method, route string, status int, duration 
 
 func (m *Metrics) RecordJudgeTaskDispatch(result string) {
 	m.judgeDispatches.WithLabelValues(result).Inc()
+}
+
+// RecordJudgeRequestPayloadSize records the serialized judge request size.
+func (m *Metrics) RecordJudgeRequestPayloadSize(bytes int) {
+	if bytes < 0 {
+		bytes = 0
+	}
+	m.judgeRequestPayload.Observe(float64(bytes))
+}
+
+// RecordTestcaseCache records a testcase cache lookup outcome.
+func (m *Metrics) RecordTestcaseCache(result string) {
+	m.testcaseCache.WithLabelValues(testcaseCacheResultLabel(result)).Inc()
+}
+
+// ObserveTestcaseCachePhase records testcase archive loading work.
+func (m *Metrics) ObserveTestcaseCachePhase(phase, result string, duration time.Duration) {
+	m.testcaseCachePhase.WithLabelValues(testcaseCachePhaseLabel(phase), testcaseCachePhaseResultLabel(result)).Observe(duration.Seconds())
+}
+
+// ObserveTestcaseCacheBytes records the current parsed testcase cache size.
+func (m *Metrics) ObserveTestcaseCacheBytes(bytes int64) {
+	if bytes < 0 {
+		bytes = 0
+	}
+	m.testcaseCacheBytes.Set(float64(bytes))
+}
+
+// RecordTestcaseCacheEviction records a testcase cache eviction.
+func (m *Metrics) RecordTestcaseCacheEviction() {
+	m.testcaseCacheEvictions.Inc()
 }
 
 func (m *Metrics) RecordJudgeTaskProcess(result string, duration time.Duration) {
@@ -308,5 +386,32 @@ func boundedResultLabel(result string) string {
 		return result
 	default:
 		return "error"
+	}
+}
+
+func testcaseCacheResultLabel(result string) string {
+	switch result {
+	case "hit", "miss", "error":
+		return result
+	default:
+		return "error"
+	}
+}
+
+func testcaseCachePhaseResultLabel(result string) string {
+	switch result {
+	case "success", "error":
+		return result
+	default:
+		return "error"
+	}
+}
+
+func testcaseCachePhaseLabel(phase string) string {
+	switch phase {
+	case "download", "unpack":
+		return phase
+	default:
+		return "unknown"
 	}
 }

--- a/internal/observability/metrics_test.go
+++ b/internal/observability/metrics_test.go
@@ -22,6 +22,13 @@ func TestMetricsExposeJudgeAgentAndSandboxSignals(t *testing.T) {
 	metrics.RecordJudgeTaskRecovery("recover_dead_task", "success")
 	metrics.RecordReconcilerAction("reset_stale_tasks", "success", 2)
 	metrics.RecordRejudgeBatch("create", "problem", "success")
+	metrics.RecordJudgeRequestPayloadSize(1024)
+	metrics.RecordTestcaseCache("miss")
+	metrics.RecordTestcaseCache("hit")
+	metrics.ObserveTestcaseCachePhase("download", "success", 20*time.Millisecond)
+	metrics.ObserveTestcaseCachePhase("unpack", "error", 30*time.Millisecond)
+	metrics.ObserveTestcaseCacheBytes(4096)
+	metrics.RecordTestcaseCacheEviction()
 
 	rec := httptest.NewRecorder()
 	metrics.Handler().ServeHTTP(rec, httptest.NewRequest("GET", "/metrics", nil))
@@ -44,6 +51,11 @@ func TestMetricsExposeJudgeAgentAndSandboxSignals(t *testing.T) {
 		"soj_worker_judge_task_recovery_total",
 		"soj_worker_reconciliation_total",
 		`soj_rejudge_batches_total{action="create",result="success",service="test",target="problem"} 1`,
+		"soj_worker_judge_request_payload_size_bytes",
+		"soj_judge_agent_testcase_cache_total",
+		"soj_judge_agent_testcase_cache_phase_duration_seconds",
+		`soj_judge_agent_testcase_cache_bytes{service="test"} 4096`,
+		"soj_judge_agent_testcase_cache_evictions_total",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("metrics body missing %s:\n%s", want, body)

--- a/internal/problem/problem_reader.go
+++ b/internal/problem/problem_reader.go
@@ -206,12 +206,14 @@ func (r *ProblemReader) CurrentReadyTestcaseSet(ctx context.Context, problemID i
 		}
 		return TestcaseSet{}, err
 	}
-	cases, err := parseTestcaseArchiveCases(data, time.Duration(p.TimeLimitMS)*time.Millisecond, int64(p.MemoryLimitKB))
+	cases, err := ParseTestcaseArchive(data, TestcaseArchiveOptions{
+		ExpectedCaseCount: set.CaseCount,
+		ExpectedSHA256:    set.ChecksumSHA256,
+		TimeLimit:         time.Duration(p.TimeLimitMS) * time.Millisecond,
+		MemoryKB:          int64(p.MemoryLimitKB),
+	})
 	if err != nil {
 		return TestcaseSet{}, err
-	}
-	if set.CaseCount > 0 && int32(len(cases)) != set.CaseCount {
-		return TestcaseSet{}, apperror.BadRequest("testcase.case_count_mismatch", "case_count does not match input/output pairs")
 	}
 	return TestcaseSet{
 		ID:        set.ID,

--- a/internal/problem/testcase.go
+++ b/internal/problem/testcase.go
@@ -18,7 +18,9 @@ import (
 var caseNameRE = regexp.MustCompile(`^(?:input|output)([0-9]+)\.(?:txt|in|out)$`)
 
 const (
-	defaultMaxTestcaseArchiveBytes       = 128 << 20
+	// MaxTestcaseArchiveBytes is the maximum stored testcase archive size.
+	MaxTestcaseArchiveBytes              = 128 << 20
+	defaultMaxTestcaseArchiveBytes       = MaxTestcaseArchiveBytes
 	defaultMaxTestcaseUploadRequestBytes = defaultMaxTestcaseArchiveBytes + (1 << 20)
 	defaultMaxTestcaseEntryBytes         = 16 << 20
 	defaultMaxTestcaseTotalBytes         = 128 << 20
@@ -35,11 +37,48 @@ type testcaseArchiveLimits struct {
 }
 
 var defaultTestcaseArchiveLimits = testcaseArchiveLimits{
-	maxArchiveBytes:     defaultMaxTestcaseArchiveBytes,
+	maxArchiveBytes:     MaxTestcaseArchiveBytes,
 	maxEntryBytes:       defaultMaxTestcaseEntryBytes,
 	maxTotalBytes:       defaultMaxTestcaseTotalBytes,
 	maxFiles:            defaultMaxTestcaseFiles,
 	maxCompressionRatio: defaultMaxTestcaseCompressionRatio,
+}
+
+// TestcaseArchiveOptions controls testcase archive validation and case limits.
+type TestcaseArchiveOptions struct {
+	ExpectedCaseCount int32
+	ExpectedSHA256    string
+	MaxSizeBytes      int64
+	TimeLimit         time.Duration
+	MemoryKB          int64
+}
+
+// ParseTestcaseArchive validates and parses a testcase archive into judge cases.
+func ParseTestcaseArchive(data []byte, options TestcaseArchiveOptions) ([]Testcase, error) {
+	maxSizeBytes := options.MaxSizeBytes
+	if maxSizeBytes <= 0 {
+		maxSizeBytes = MaxTestcaseArchiveBytes
+	}
+	if strings.TrimSpace(options.ExpectedSHA256) != "" {
+		if err := validateTestcaseArchive(data, options.ExpectedCaseCount, options.ExpectedSHA256, maxSizeBytes); err != nil {
+			return nil, err
+		}
+	} else {
+		limits := defaultTestcaseArchiveLimits
+		limits.maxArchiveBytes = maxSizeBytes
+		if err := validateTestcaseArchiveResources(data, limits); err != nil {
+			return nil, testcaseArchiveBadRequest(err)
+		}
+	}
+
+	cases, err := parseTestcaseArchiveCases(data, options.TimeLimit, options.MemoryKB)
+	if err != nil {
+		return nil, err
+	}
+	if options.ExpectedCaseCount > 0 && int32(len(cases)) != options.ExpectedCaseCount {
+		return nil, apperror.BadRequest("testcase.case_count_mismatch", "case_count does not match input/output pairs")
+	}
+	return cases, nil
 }
 
 type testcaseArchiveResourceError struct {

--- a/internal/submission/async.go
+++ b/internal/submission/async.go
@@ -40,6 +40,7 @@ type CoreJudge interface {
 type CoreAsyncAgentOptions struct {
 	Core            CoreJudge
 	SourceStore     sourceReader
+	TestcaseLoader  testcaseLoader
 	ResultPublisher ResultPublisher
 	Now             func() time.Time
 }
@@ -47,6 +48,7 @@ type CoreAsyncAgentOptions struct {
 type CoreAsyncAgent struct {
 	core            CoreJudge
 	sourceStore     sourceReader
+	testcaseLoader  testcaseLoader
 	resultPublisher ResultPublisher
 	now             func() time.Time
 }
@@ -64,7 +66,7 @@ func NewCoreAsyncAgent(options CoreAsyncAgentOptions) *CoreAsyncAgent {
 	if now == nil {
 		now = func() time.Time { return time.Now().UTC() }
 	}
-	return &CoreAsyncAgent{core: options.Core, sourceStore: options.SourceStore, resultPublisher: options.ResultPublisher, now: now}
+	return &CoreAsyncAgent{core: options.Core, sourceStore: options.SourceStore, testcaseLoader: options.TestcaseLoader, resultPublisher: options.ResultPublisher, now: now}
 }
 
 func (a *FakeAsyncAgent) ProcessRequestMessage(ctx context.Context, message queue.Message, requestQueue MessageAcker) error {
@@ -126,15 +128,21 @@ func (a *CoreAsyncAgent) ProcessRequestMessage(ctx context.Context, message queu
 	if err != nil {
 		return err
 	}
-	cases := make([]judgecore.Case, 0, len(request.Testcases))
-	for _, item := range request.Testcases {
+	if a.testcaseLoader == nil {
+		return fmt.Errorf("testcase loader is required")
+	}
+	testcaseSet, err := a.testcaseLoader.Load(ctx, request.TestcaseSet)
+	if err != nil {
+		return err
+	}
+	cases := make([]judgecore.Case, 0, len(testcaseSet))
+	for i, item := range testcaseSet {
 		cases = append(cases, judgecore.Case{
-			Index:          item.Index,
+			Index:          i + 1,
 			Input:          item.InputKey,
-			ExpectedOutput: item.ExpectedOutputKey,
-			TimeLimit:      time.Duration(item.TimeLimitMS) * time.Millisecond,
+			ExpectedOutput: item.OutputKey,
+			TimeLimit:      item.TimeLimit,
 			MemoryKB:       item.MemoryKB,
-			Score:          item.Score,
 		})
 	}
 	result, err := a.core.Judge(ctx, judgecore.Request{
@@ -147,7 +155,7 @@ func (a *CoreAsyncAgent) ProcessRequestMessage(ctx context.Context, message queu
 	if err != nil {
 		return err
 	}
-	result.Manifest.TestcaseSetHash = request.TestcaseSet.Hash
+	result.Manifest.TestcaseSetHash = request.TestcaseSet.ChecksumSHA256
 	result.Manifest.TraceID = request.TraceID
 	attachTestcaseKeys(request, result.Cases)
 	if err := publishAsyncResult(ctx, a.resultPublisher, request, result, a.now); err != nil {

--- a/internal/submission/async_test.go
+++ b/internal/submission/async_test.go
@@ -11,6 +11,7 @@ import (
 	judgeevents "SOJ/internal/judge/events"
 	"SOJ/internal/judgecore"
 	"SOJ/internal/judgecore/language"
+	"SOJ/internal/problem"
 	"SOJ/internal/queue"
 
 	"go.opentelemetry.io/otel/trace"
@@ -70,12 +71,18 @@ func TestDispatcherPublishesRequestEventWithoutCallingJudgeEngine(t *testing.T) 
 	if event.TraceContext != (judgeevents.TraceContext{}) {
 		t.Fatalf("trace_context = %+v, want empty when tracing is disabled", event.TraceContext)
 	}
+	if event.TestcaseSet.StorageKey != "cases.zip" || event.TestcaseSet.CaseCount != 1 || event.TestcaseSet.ChecksumSHA256 != "cases-hash" {
+		t.Fatalf("testcase reference = %+v", event.TestcaseSet)
+	}
 	var raw map[string]any
 	if err := json.Unmarshal(q.payloads[0], &raw); err != nil {
 		t.Fatalf("decode raw request event: %v", err)
 	}
 	if _, ok := raw["trace_context"]; ok {
 		t.Fatalf("trace_context serialized while tracing is disabled: %s", q.payloads[0])
+	}
+	if _, ok := raw["testcases"]; ok {
+		t.Fatalf("testcase contents serialized in request event: %s", q.payloads[0])
 	}
 }
 
@@ -137,7 +144,7 @@ func TestFakeAsyncAgentPublishesResultBeforeRequestAck(t *testing.T) {
 		SubmissionID:   9,
 		LanguageID:     71,
 		SourceArtifact: judgeevents.ArtifactRef{ID: 4, StorageKey: "source/key", ContentHash: "sha256:source"},
-		TestcaseSet:    judgeevents.TestcaseSetRef{ID: 3, Hash: "cases-hash"},
+		TestcaseSet:    testRequestTestcaseSet(),
 		TimeoutMS:      1000,
 		CreatedAt:      time.Unix(100, 0).UTC(),
 	}
@@ -193,7 +200,7 @@ func TestFakeAsyncAgentPropagatesRequestTraceContextToJudgeAndResult(t *testing.
 			StorageKey:  "source/key",
 			ContentHash: "sha256:source",
 		},
-		TestcaseSet: judgeevents.TestcaseSetRef{ID: 3, Hash: "cases-hash"},
+		TestcaseSet: testRequestTestcaseSet(),
 		TimeoutMS:   1000,
 		CreatedAt:   time.Unix(100, 0).UTC(),
 	}
@@ -238,17 +245,10 @@ func main() { var a, b int; fmt.Scan(&a, &b); fmt.Println(a + b) }
 		SubmissionID:   9,
 		LanguageID:     language.GoID,
 		SourceArtifact: judgeevents.ArtifactRef{ID: 4, StorageKey: "source/key", ContentHash: "sha256:source"},
-		TestcaseSet:    judgeevents.TestcaseSetRef{ID: 3, Hash: "cases-hash"},
-		Testcases: []judgeevents.TestcaseRef{{
-			Index:             1,
-			InputKey:          "1 2\n",
-			ExpectedOutputKey: "3\n",
-			TimeLimitMS:       5000,
-			MemoryKB:          262144,
-		}},
-		TimeoutMS: 5000,
-		MemoryKB:  262144,
-		CreatedAt: time.Unix(100, 0).UTC(),
+		TestcaseSet:    testRequestTestcaseSet(),
+		TimeoutMS:      5000,
+		MemoryKB:       262144,
+		CreatedAt:      time.Unix(100, 0).UTC(),
 	}
 	payload, err := json.Marshal(request)
 	if err != nil {
@@ -258,6 +258,7 @@ func main() { var a, b int; fmt.Scan(&a, &b); fmt.Println(a + b) }
 	agent := NewCoreAsyncAgent(CoreAsyncAgentOptions{
 		Core:            judgecore.New(judgecore.Options{}),
 		SourceStore:     store,
+		TestcaseLoader:  asyncTestcaseLoader{cases: []problem.Testcase{{InputKey: "1 2\n", OutputKey: "3\n", TimeLimit: 5 * time.Second, MemoryKB: 262144}}},
 		ResultPublisher: resultQueue,
 		Now:             func() time.Time { return time.Unix(101, 0).UTC() },
 	})
@@ -291,6 +292,25 @@ func main() { var a, b int; fmt.Scan(&a, &b); fmt.Println(a + b) }
 	if result.Result.Manifest.TestcaseSetHash != "cases-hash" || result.Result.Manifest.TraceID != "trace-core" {
 		t.Fatalf("manifest = %+v", result.Result.Manifest)
 	}
+}
+
+func testRequestTestcaseSet() judgeevents.TestcaseSetRef {
+	return judgeevents.TestcaseSetRef{
+		ID:             3,
+		ChecksumSHA256: "cases-hash",
+		StorageKey:     "cases.zip",
+		CaseCount:      1,
+		TimeLimitMS:    5000,
+		MemoryKB:       262144,
+	}
+}
+
+type asyncTestcaseLoader struct {
+	cases []problem.Testcase
+}
+
+func (l asyncTestcaseLoader) Load(context.Context, judgeevents.TestcaseSetRef) ([]problem.Testcase, error) {
+	return append([]problem.Testcase(nil), l.cases...), nil
 }
 
 func TestResultConsumerIsIdempotentAndAcksAfterPersist(t *testing.T) {

--- a/internal/submission/component_ports_test.go
+++ b/internal/submission/component_ports_test.go
@@ -34,13 +34,7 @@ func (s *submissionCreatorStoreStub) CreateSubmissionWithTask(_ context.Context,
 type submissionCreatorProblemReaderStub struct{}
 
 func (submissionCreatorProblemReaderStub) GetForJudge(context.Context, int64) (problem.Problem, error) {
-	return problem.Problem{ID: 1}, nil
-}
-
-type submissionCreatorTestcaseResolverStub struct{}
-
-func (submissionCreatorTestcaseResolverStub) CurrentReadyTestcaseSet(context.Context, int64) (problem.TestcaseSet, error) {
-	return problem.TestcaseSet{ID: 3}, nil
+	return problem.Problem{ID: 1, CurrentTestcaseSetID: 3}, nil
 }
 
 type sourceWriterStub struct{}
@@ -70,12 +64,11 @@ func (contestSubmissionPolicyStub) ValidateSubmission(context.Context, auth.Acto
 func TestSubmissionCreatorUsesOnlyCreationStore(t *testing.T) {
 	contestID := int64(2)
 	creator := NewSubmissionCreator(SubmissionCreatorOptions{
-		Store:            &submissionCreatorStoreStub{},
-		ProblemReader:    submissionCreatorProblemReaderStub{},
-		TestcaseResolver: submissionCreatorTestcaseResolverStub{},
-		SourceStore:      sourceWriterStub{},
-		ContestPolicy:    contestSubmissionPolicyStub{},
-		Now:              func() time.Time { return time.Unix(10, 0).UTC() },
+		Store:         &submissionCreatorStoreStub{},
+		ProblemReader: submissionCreatorProblemReaderStub{},
+		SourceStore:   sourceWriterStub{},
+		ContestPolicy: contestSubmissionPolicyStub{},
+		Now:           func() time.Time { return time.Unix(10, 0).UTC() },
 	})
 
 	created, err := creator.CreateSubmission(t.Context(), auth.Actor{UserID: 7, Role: auth.RoleUser}, CreateSubmissionInput{
@@ -87,7 +80,7 @@ func TestSubmissionCreatorUsesOnlyCreationStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSubmission() error = %v", err)
 	}
-	if created.Submission.ID == 0 || created.Task.SubmissionID != created.Submission.ID {
+	if created.Submission.ID == 0 || created.Task.SubmissionID != created.Submission.ID || created.Submission.TestcaseSetID != 3 {
 		t.Fatalf("CreateSubmission() = %+v", created)
 	}
 }

--- a/internal/submission/construction_test.go
+++ b/internal/submission/construction_test.go
@@ -30,10 +30,6 @@ func newServiceForTest(options serviceTestOptions) *Service {
 	if problems == nil {
 		problems = fakeProblemReader{}
 	}
-	testcases := options.TestcaseResolver
-	if testcases == nil {
-		testcases = fakeTestcaseResolver{}
-	}
 	sourceStore := options.SourceStore
 	if sourceStore == nil {
 		sourceStore = NewMemorySourceStore()
@@ -43,12 +39,11 @@ func newServiceForTest(options serviceTestOptions) *Service {
 		judgeEngine = judge.NewFakeEngine()
 	}
 	creator := NewSubmissionCreator(SubmissionCreatorOptions{
-		Store:            options.Repository,
-		ProblemReader:    problems,
-		TestcaseResolver: testcases,
-		SourceStore:      sourceStore,
-		ContestPolicy:    options.ContestSubmissionPolicy,
-		Now:              options.Now,
+		Store:         options.Repository,
+		ProblemReader: problems,
+		SourceStore:   sourceStore,
+		ContestPolicy: options.ContestSubmissionPolicy,
+		Now:           options.Now,
 	})
 	reader := NewSubmissionReader(options.Repository, options.ContestVisibilityPolicy)
 	runs := NewRunService(RunServiceOptions{
@@ -72,7 +67,7 @@ type workerTestOptions struct {
 	Queue            queue.TaskQueue
 	Judge            judgeRunner
 	ProblemReader    problem.Reader
-	TestcaseResolver testcaseSnapshotResolver
+	TestcaseResolver workerTestcaseResolver
 	SourceStore      sourceReader
 	MaxAttempts      int32
 	Backoff          func(int32) time.Duration
@@ -83,6 +78,11 @@ type workerTestOptions struct {
 type workerTestMetrics interface {
 	taskDispatchMetrics
 	taskProcessMetrics
+}
+
+type workerTestcaseResolver interface {
+	testcaseSnapshotResolver
+	testcaseMetadataResolver
 }
 
 func newWorkerForTest(options workerTestOptions) *Worker {

--- a/internal/submission/service_test.go
+++ b/internal/submission/service_test.go
@@ -1374,7 +1374,7 @@ func TestHandlerCreateRunReturnsOpenAPIShapeAndShortWaitStatus(t *testing.T) {
 type fakeProblemReader struct{}
 
 func (fakeProblemReader) GetForJudge(ctx context.Context, problemID int64) (problem.Problem, error) {
-	return problem.Problem{ID: problemID}, nil
+	return problem.Problem{ID: problemID, CurrentTestcaseSetID: 3}, nil
 }
 
 type fakeTestcaseResolver struct{}
@@ -1385,6 +1385,10 @@ func (fakeTestcaseResolver) CurrentReadyTestcaseSet(ctx context.Context, problem
 
 func (fakeTestcaseResolver) ReadyTestcaseSet(ctx context.Context, problemID, testcaseSetID int64) (problem.TestcaseSet, error) {
 	return problem.TestcaseSet{ID: testcaseSetID, ProblemID: problemID, Status: "ready", Cases: []problem.Testcase{{InputKey: "in", OutputKey: "out", TimeLimit: time.Second, MemoryKB: 262144}}}, nil
+}
+
+func (fakeTestcaseResolver) ReadyTestcaseMetadata(ctx context.Context, problemID, testcaseSetID int64) (testcaseMetadata, error) {
+	return testcaseMetadata{ID: testcaseSetID, StorageKey: "cases.zip", ChecksumSHA256: "cases-hash", CaseCount: 1, TimeLimit: time.Second, MemoryKB: 262144}, nil
 }
 
 type fakeSnapshotTestcaseResolver struct {
@@ -1398,6 +1402,11 @@ func (r fakeSnapshotTestcaseResolver) CurrentReadyTestcaseSet(ctx context.Contex
 
 func (r fakeSnapshotTestcaseResolver) ReadyTestcaseSet(ctx context.Context, problemID, testcaseSetID int64) (problem.TestcaseSet, error) {
 	return r.byID[testcaseSetID], nil
+}
+
+func (r fakeSnapshotTestcaseResolver) ReadyTestcaseMetadata(ctx context.Context, problemID, testcaseSetID int64) (testcaseMetadata, error) {
+	set := r.byID[testcaseSetID]
+	return testcaseMetadata{ID: testcaseSetID, StorageKey: "cases.zip", ChecksumSHA256: "cases-hash", CaseCount: int32(len(set.Cases)), TimeLimit: time.Second, MemoryKB: 262144}, nil
 }
 
 type memoryQueue struct {
@@ -1450,6 +1459,8 @@ type recordingWorkerMetrics struct {
 func (m *recordingWorkerMetrics) RecordJudgeTaskDispatch(result string) {
 	m.dispatched = append(m.dispatched, result)
 }
+
+func (m *recordingWorkerMetrics) RecordJudgeRequestPayloadSize(bytes int) {}
 
 func (m *recordingWorkerMetrics) RecordJudgeTaskProcess(result string, duration time.Duration) {
 	m.processed = append(m.processed, recordedWorkerProcess{result: result, duration: duration})

--- a/internal/submission/storage.go
+++ b/internal/submission/storage.go
@@ -1,7 +1,6 @@
 package submission
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	crand "crypto/rand"
@@ -10,9 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -82,34 +78,22 @@ func NewTestcaseSnapshotResolver(q *db.Queries, objectStorage storage.ObjectStor
 	return &TestcaseSnapshotResolver{q: q, storage: objectStorage}
 }
 
-func (r *TestcaseSnapshotResolver) CurrentReadyTestcaseSet(ctx context.Context, problemID int64) (problem.TestcaseSet, error) {
-	row, err := r.q.GetCurrentReadyTestcaseSet(ctx, problemID)
-	if err != nil {
-		return problem.TestcaseSet{}, err
-	}
-	return r.testcaseSetFromRow(ctx, row.ID, row.ProblemID, int(row.Version), row.Status, row.StorageKey)
-}
-
 func (r *TestcaseSnapshotResolver) ReadyTestcaseSet(ctx context.Context, problemID, testcaseSetID int64) (problem.TestcaseSet, error) {
 	row, err := r.q.GetReadyTestcaseSetByID(ctx, db.GetReadyTestcaseSetByIDParams{ID: testcaseSetID, ProblemID: problemID})
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
-	return r.testcaseSetFromRow(ctx, row.ID, row.ProblemID, int(row.Version), row.Status, row.StorageKey)
-}
-
-func (r *TestcaseSnapshotResolver) testcaseSetFromRow(ctx context.Context, id, problemID int64, version int, status, storageKey string) (problem.TestcaseSet, error) {
 	if r.storage == nil {
 		return problem.TestcaseSet{}, apperror.ServiceUnavailable("testcase object storage unavailable")
 	}
-	if strings.TrimSpace(storageKey) == "" {
+	if strings.TrimSpace(row.StorageKey) == "" {
 		return problem.TestcaseSet{}, apperror.BadRequest("testcase.archive_missing", "testcase archive storage key is missing")
 	}
 	problemRow, err := r.q.GetProblemByID(ctx, problemID)
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
-	body, _, err := r.storage.Get(ctx, storageKey)
+	body, _, err := r.storage.Get(ctx, row.StorageKey)
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
@@ -117,79 +101,51 @@ func (r *TestcaseSnapshotResolver) testcaseSetFromRow(ctx context.Context, id, p
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
-	cases, err := parseSnapshotTestcaseCases(data, time.Duration(problemRow.TimeLimitMs)*time.Millisecond, int64(problemRow.MemoryLimitKb))
+	cases, err := problem.ParseTestcaseArchive(data, problem.TestcaseArchiveOptions{
+		ExpectedCaseCount: row.CaseCount,
+		ExpectedSHA256:    row.ChecksumSha256,
+		TimeLimit:         time.Duration(problemRow.TimeLimitMs) * time.Millisecond,
+		MemoryKB:          int64(problemRow.MemoryLimitKb),
+	})
 	if err != nil {
 		return problem.TestcaseSet{}, err
 	}
-	return problem.TestcaseSet{ID: id, ProblemID: problemID, Version: version, Status: status, Cases: cases}, nil
+	return problem.TestcaseSet{ID: row.ID, ProblemID: row.ProblemID, Version: int(row.Version), Status: row.Status, Cases: cases}, nil
 }
 
-var snapshotCaseNameRE = regexp.MustCompile(`^(input|output)(\d+)\.txt$`)
-
-func parseSnapshotTestcaseCases(data []byte, defaultTimeLimit time.Duration, defaultMemoryKB int64) ([]problem.Testcase, error) {
-	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
-	if err != nil {
-		return nil, apperror.BadRequest("testcase.zip_invalid", "testcase archive must be a valid zip file")
-	}
-	inputs := map[string]string{}
-	outputs := map[string]string{}
-	for _, file := range reader.File {
-		if file.FileInfo().IsDir() {
-			continue
-		}
-		name := strings.ToLower(path.Base(file.Name))
-		matches := snapshotCaseNameRE.FindStringSubmatch(name)
-		if len(matches) != 3 {
-			continue
-		}
-		content, err := readSnapshotZipFile(file)
-		if err != nil {
-			return nil, err
-		}
-		if matches[1] == "input" {
-			inputs[matches[2]] = content
-		} else {
-			outputs[matches[2]] = content
-		}
-	}
-
-	ids := make([]string, 0, len(inputs))
-	for id := range inputs {
-		if _, ok := outputs[id]; !ok {
-			return nil, apperror.BadRequest("testcase.output_missing", "each input must have a matching output")
-		}
-		ids = append(ids, id)
-	}
-	for id := range outputs {
-		if _, ok := inputs[id]; !ok {
-			return nil, apperror.BadRequest("testcase.input_missing", "each output must have a matching input")
-		}
-	}
-	sort.Slice(ids, func(i, j int) bool {
-		if len(ids[i]) != len(ids[j]) {
-			return len(ids[i]) < len(ids[j])
-		}
-		return ids[i] < ids[j]
-	})
-
-	cases := make([]problem.Testcase, 0, len(ids))
-	for i, id := range ids {
-		cases = append(cases, problem.Testcase{ID: int64(i + 1), InputKey: inputs[id], OutputKey: outputs[id], TimeLimit: defaultTimeLimit, MemoryKB: defaultMemoryKB})
-	}
-	if len(cases) == 0 {
-		return nil, apperror.BadRequest("testcase.case_count_mismatch", "testcase archive has no input/output pairs")
-	}
-	return cases, nil
+type testcaseMetadata struct {
+	ID             int64
+	StorageKey     string
+	ChecksumSHA256 string
+	CaseCount      int32
+	TimeLimit      time.Duration
+	MemoryKB       int64
 }
 
-func readSnapshotZipFile(file *zip.File) (string, error) {
-	reader, err := file.Open()
+func (r *TestcaseSnapshotResolver) ReadyTestcaseMetadata(ctx context.Context, problemID, testcaseSetID int64) (testcaseMetadata, error) {
+	row, err := r.q.GetReadyTestcaseSetByID(ctx, db.GetReadyTestcaseSetByIDParams{ID: testcaseSetID, ProblemID: problemID})
 	if err != nil {
-		return "", fmt.Errorf("open testcase file %s: %w", file.Name, err)
+		return testcaseMetadata{}, err
 	}
-	data, err := readAllAndClose(reader)
+	problemRow, err := r.q.GetProblemByID(ctx, problemID)
 	if err != nil {
-		return "", fmt.Errorf("read testcase file %s: %w", file.Name, err)
+		return testcaseMetadata{}, err
 	}
-	return string(data), nil
+	if strings.TrimSpace(row.StorageKey) == "" {
+		return testcaseMetadata{}, apperror.BadRequest("testcase.archive_missing", "testcase archive storage key is missing")
+	}
+	if strings.TrimSpace(row.ChecksumSha256) == "" {
+		return testcaseMetadata{}, apperror.BadRequest("testcase.checksum_missing", "testcase archive checksum is missing")
+	}
+	if row.CaseCount <= 0 {
+		return testcaseMetadata{}, apperror.BadRequest("testcase.case_count_mismatch", "testcase archive case count is invalid")
+	}
+	return testcaseMetadata{
+		ID:             row.ID,
+		StorageKey:     row.StorageKey,
+		ChecksumSHA256: row.ChecksumSha256,
+		CaseCount:      row.CaseCount,
+		TimeLimit:      time.Duration(problemRow.TimeLimitMs) * time.Millisecond,
+		MemoryKB:       int64(problemRow.MemoryLimitKb),
+	}, nil
 }

--- a/internal/submission/storage_test.go
+++ b/internal/submission/storage_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"SOJ/internal/problem"
 	"SOJ/internal/storage"
 )
 
@@ -23,15 +24,15 @@ func TestObjectSourceStoreGetReturnsCloseError(t *testing.T) {
 	}
 }
 
-func TestParseSnapshotTestcaseCasesAppliesProblemLimits(t *testing.T) {
+func TestParseTestcaseArchiveAppliesProblemLimits(t *testing.T) {
 	archive := snapshotZipArchive(t, map[string]string{
 		"input1.txt":  "1 1\n",
 		"output1.txt": "2\n",
 	})
 
-	cases, err := parseSnapshotTestcaseCases(archive, 10*time.Second, 262144)
+	cases, err := problem.ParseTestcaseArchive(archive, problem.TestcaseArchiveOptions{TimeLimit: 10 * time.Second, MemoryKB: 262144})
 	if err != nil {
-		t.Fatalf("parseSnapshotTestcaseCases returned error: %v", err)
+		t.Fatalf("ParseTestcaseArchive returned error: %v", err)
 	}
 	if len(cases) != 1 {
 		t.Fatalf("cases = %d, want 1", len(cases))

--- a/internal/submission/submission_creator.go
+++ b/internal/submission/submission_creator.go
@@ -19,19 +19,17 @@ type submissionCreationStore interface {
 type SubmissionCreator struct {
 	store         submissionCreationStore
 	problems      problem.Reader
-	testcases     problem.TestcaseResolver
 	sourceStore   sourceWriter
 	contestPolicy ContestSubmissionPolicy
 	now           func() time.Time
 }
 
 type SubmissionCreatorOptions struct {
-	Store            submissionCreationStore
-	ProblemReader    problem.Reader
-	TestcaseResolver problem.TestcaseResolver
-	SourceStore      sourceWriter
-	ContestPolicy    ContestSubmissionPolicy
-	Now              func() time.Time
+	Store         submissionCreationStore
+	ProblemReader problem.Reader
+	SourceStore   sourceWriter
+	ContestPolicy ContestSubmissionPolicy
+	Now           func() time.Time
 }
 
 func NewSubmissionCreator(options SubmissionCreatorOptions) *SubmissionCreator {
@@ -42,7 +40,6 @@ func NewSubmissionCreator(options SubmissionCreatorOptions) *SubmissionCreator {
 	return &SubmissionCreator{
 		store:         options.Store,
 		problems:      options.ProblemReader,
-		testcases:     options.TestcaseResolver,
 		sourceStore:   options.SourceStore,
 		contestPolicy: options.ContestPolicy,
 		now:           now,
@@ -56,17 +53,14 @@ func (s *SubmissionCreator) CreateSubmission(ctx context.Context, actor auth.Act
 	if len(input.Source) == 0 {
 		return CreateSubmissionOutput{}, apperror.BadRequest("source_required", "source is required")
 	}
-	if _, err := s.problems.GetForJudge(ctx, input.ProblemID); err != nil {
+	problemForJudge, err := s.problems.GetForJudge(ctx, input.ProblemID)
+	if err != nil {
 		return CreateSubmissionOutput{}, err
 	}
 	if input.ContestID != nil && s.contestPolicy != nil {
 		if err := s.contestPolicy.ValidateSubmission(ctx, actor, input.ProblemID, *input.ContestID); err != nil {
 			return CreateSubmissionOutput{}, err
 		}
-	}
-	testcaseSet, err := s.testcases.CurrentReadyTestcaseSet(ctx, input.ProblemID)
-	if err != nil {
-		return CreateSubmissionOutput{}, err
 	}
 	if _, err := s.store.GetEnabledLanguage(ctx, input.LanguageID); err != nil {
 		return CreateSubmissionOutput{}, err
@@ -93,7 +87,7 @@ func (s *SubmissionCreator) CreateSubmission(ctx context.Context, actor auth.Act
 		ProblemID:        input.ProblemID,
 		ContestID:        input.ContestID,
 		LanguageID:       input.LanguageID,
-		TestcaseSetID:    testcaseSet.ID,
+		TestcaseSetID:    problemForJudge.CurrentTestcaseSetID,
 		Status:           StatusQueued,
 		SourceArtifactID: artifact.ID,
 	}, s.now())

--- a/internal/submission/testcase_cache.go
+++ b/internal/submission/testcase_cache.go
@@ -1,0 +1,262 @@
+package submission
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	judgeevents "SOJ/internal/judge/events"
+	"SOJ/internal/problem"
+	"SOJ/internal/storage"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const defaultTestcaseCacheBytes = 256 << 20
+
+type testcaseLoader interface {
+	Load(context.Context, judgeevents.TestcaseSetRef) ([]problem.Testcase, error)
+}
+
+type testcaseCacheMetrics interface {
+	RecordTestcaseCache(result string)
+	ObserveTestcaseCachePhase(phase, result string, duration time.Duration)
+	ObserveTestcaseCacheBytes(bytes int64)
+	RecordTestcaseCacheEviction()
+}
+
+// TestcaseCacheOptions configures the in-memory testcase cache.
+type TestcaseCacheOptions struct {
+	MaxBytes int64
+	Metrics  testcaseCacheMetrics
+}
+
+// TestcaseCache stores parsed testcase sets with a bounded LRU policy.
+type TestcaseCache struct {
+	storage  storage.ObjectStorage
+	metrics  testcaseCacheMetrics
+	maxBytes int64
+
+	mu           sync.Mutex
+	entries      map[testcaseCacheKey]*list.Element
+	lru          *list.List
+	currentBytes int64
+	loads        singleflight.Group
+}
+
+type testcaseCacheKey struct {
+	id   int64
+	hash string
+}
+
+type testcaseCacheEntry struct {
+	key   testcaseCacheKey
+	cases []problem.Testcase
+	bytes int64
+}
+
+// NewTestcaseCache creates a testcase cache backed by object storage.
+func NewTestcaseCache(objectStorage storage.ObjectStorage, options TestcaseCacheOptions) *TestcaseCache {
+	maxBytes := options.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = defaultTestcaseCacheBytes
+	}
+	return &TestcaseCache{
+		storage:  objectStorage,
+		metrics:  options.Metrics,
+		maxBytes: maxBytes,
+		entries:  make(map[testcaseCacheKey]*list.Element),
+		lru:      list.New(),
+	}
+}
+
+// Load returns the parsed testcase set identified by the event reference.
+func (c *TestcaseCache) Load(ctx context.Context, ref judgeevents.TestcaseSetRef) ([]problem.Testcase, error) {
+	key, err := testcaseCacheKeyFromRef(ref)
+	if err != nil {
+		c.record("error")
+		return nil, err
+	}
+	if cases, ok := c.get(key); ok {
+		c.record("hit")
+		return cases, nil
+	}
+	c.record("miss")
+
+	value, err, _ := c.loads.Do(key.string(), func() (any, error) {
+		if cases, ok := c.get(key); ok {
+			return cases, nil
+		}
+		data, err := c.download(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		started := time.Now()
+		cases, err := problem.ParseTestcaseArchive(data, problem.TestcaseArchiveOptions{
+			ExpectedCaseCount: ref.CaseCount,
+			ExpectedSHA256:    ref.ChecksumSHA256,
+			TimeLimit:         time.Duration(ref.TimeLimitMS) * time.Millisecond,
+			MemoryKB:          ref.MemoryKB,
+		})
+		if c.metrics != nil {
+			result := "success"
+			if err != nil {
+				result = "error"
+			}
+			c.metrics.ObserveTestcaseCachePhase("unpack", result, time.Since(started))
+		}
+		if err != nil {
+			return nil, err
+		}
+		c.put(key, cases)
+		return cases, nil
+	})
+	if err != nil {
+		c.record("error")
+		return nil, err
+	}
+	return cloneTestcases(value.([]problem.Testcase)), nil
+}
+
+func testcaseCacheKeyFromRef(ref judgeevents.TestcaseSetRef) (testcaseCacheKey, error) {
+	if ref.ID <= 0 {
+		return testcaseCacheKey{}, errors.New("testcase_set.id must be positive")
+	}
+	if strings.TrimSpace(ref.ChecksumSHA256) == "" {
+		return testcaseCacheKey{}, errors.New("testcase_set.checksum_sha256 is required")
+	}
+	if strings.TrimSpace(ref.StorageKey) == "" {
+		return testcaseCacheKey{}, errors.New("testcase_set.storage_key is required")
+	}
+	if ref.CaseCount <= 0 {
+		return testcaseCacheKey{}, errors.New("testcase_set.case_count must be positive")
+	}
+	return testcaseCacheKey{id: ref.ID, hash: strings.ToLower(strings.TrimSpace(ref.ChecksumSHA256))}, nil
+}
+
+func (k testcaseCacheKey) string() string {
+	return fmt.Sprintf("%d:%s", k.id, k.hash)
+}
+
+func (c *TestcaseCache) download(ctx context.Context, ref judgeevents.TestcaseSetRef) ([]byte, error) {
+	started := time.Now()
+	if c.storage == nil {
+		c.observeDownload("error", started)
+		return nil, errors.New("testcase object storage unavailable")
+	}
+	body, info, err := c.storage.Get(ctx, ref.StorageKey)
+	if err != nil {
+		c.observeDownload("error", started)
+		return nil, err
+	}
+	if body == nil {
+		c.observeDownload("error", started)
+		return nil, errors.New("testcase object body is nil")
+	}
+	if info.Size > problem.MaxTestcaseArchiveBytes {
+		_ = body.Close()
+		c.observeDownload("error", started)
+		return nil, fmt.Errorf("testcase archive exceeds %d bytes", problem.MaxTestcaseArchiveBytes)
+	}
+	data, err := readLimitedObject(body, problem.MaxTestcaseArchiveBytes)
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	c.observeDownload(result, started)
+	return data, err
+}
+
+func readLimitedObject(body io.ReadCloser, maxBytes int64) ([]byte, error) {
+	if body == nil {
+		return nil, errors.New("testcase object body is nil")
+	}
+	data, readErr := io.ReadAll(io.LimitReader(body, maxBytes+1))
+	closeErr := body.Close()
+	if readErr != nil || closeErr != nil {
+		return nil, errors.Join(readErr, closeErr)
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("testcase archive exceeds %d bytes", maxBytes)
+	}
+	return data, nil
+}
+
+func (c *TestcaseCache) observeDownload(result string, started time.Time) {
+	if c.metrics != nil {
+		c.metrics.ObserveTestcaseCachePhase("download", result, time.Since(started))
+	}
+}
+
+func (c *TestcaseCache) get(key testcaseCacheKey) ([]problem.Testcase, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	element, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	c.lru.MoveToFront(element)
+	entry := element.Value.(testcaseCacheEntry)
+	return cloneTestcases(entry.cases), true
+}
+
+func (c *TestcaseCache) put(key testcaseCacheKey, cases []problem.Testcase) {
+	entry := testcaseCacheEntry{key: key, cases: cloneTestcases(cases), bytes: testcaseBytes(cases)}
+	if entry.bytes > c.maxBytes {
+		return
+	}
+
+	c.mu.Lock()
+	if _, ok := c.entries[key]; ok {
+		c.mu.Unlock()
+		return
+	}
+	evictions := 0
+	for c.currentBytes+entry.bytes > c.maxBytes && c.lru.Len() > 0 {
+		oldest := c.lru.Back()
+		old := oldest.Value.(testcaseCacheEntry)
+		delete(c.entries, old.key)
+		c.lru.Remove(oldest)
+		c.currentBytes -= old.bytes
+		evictions++
+	}
+	c.entries[key] = c.lru.PushFront(entry)
+	c.currentBytes += entry.bytes
+	currentBytes := c.currentBytes
+	if c.metrics != nil {
+		c.metrics.ObserveTestcaseCacheBytes(currentBytes)
+	}
+	c.mu.Unlock()
+
+	if c.metrics == nil {
+		return
+	}
+	for i := 0; i < evictions; i++ {
+		c.metrics.RecordTestcaseCacheEviction()
+	}
+}
+
+func cloneTestcases(cases []problem.Testcase) []problem.Testcase {
+	return append([]problem.Testcase(nil), cases...)
+}
+
+func testcaseBytes(cases []problem.Testcase) int64 {
+	var size int64
+	for _, testcase := range cases {
+		size += int64(len(testcase.InputKey) + len(testcase.OutputKey))
+	}
+	return size
+}
+
+func (c *TestcaseCache) record(result string) {
+	if c.metrics != nil {
+		c.metrics.RecordTestcaseCache(result)
+	}
+}
+
+var _ testcaseLoader = (*TestcaseCache)(nil)

--- a/internal/submission/testcase_cache_test.go
+++ b/internal/submission/testcase_cache_test.go
@@ -1,0 +1,196 @@
+package submission
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	judgeevents "SOJ/internal/judge/events"
+	"SOJ/internal/storage"
+)
+
+func TestTestcaseCacheReusesParsedCases(t *testing.T) {
+	archive := testcaseCacheArchive(t, map[string]string{
+		"input1.txt":  "1 2\n",
+		"output1.txt": "3\n",
+	})
+	store := &testcaseCacheStorage{objects: map[string][]byte{"cases.zip": archive}}
+	cache := NewTestcaseCache(store, TestcaseCacheOptions{MaxBytes: 64})
+	ref := testcaseCacheRef(archive, 3)
+
+	first, err := cache.Load(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("first Load returned error: %v", err)
+	}
+	first[0].InputKey = "changed"
+	second, err := cache.Load(t.Context(), ref)
+	if err != nil {
+		t.Fatalf("second Load returned error: %v", err)
+	}
+	if store.gets != 1 {
+		t.Fatalf("storage gets = %d, want 1", store.gets)
+	}
+	if second[0].InputKey != "1 2\n" {
+		t.Fatalf("cached testcase was mutated: %+v", second[0])
+	}
+}
+
+func TestTestcaseCacheSingleflightLoadsOnce(t *testing.T) {
+	archive := testcaseCacheArchive(t, map[string]string{
+		"input1.txt":  "1\n",
+		"output1.txt": "1\n",
+	})
+	store := &testcaseCacheStorage{
+		objects: map[string][]byte{"cases.zip": archive},
+		delay:   25 * time.Millisecond,
+	}
+	cache := NewTestcaseCache(store, TestcaseCacheOptions{MaxBytes: 64})
+	ref := testcaseCacheRef(archive, 7)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.Load(t.Context(), ref)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Load returned error: %v", err)
+		}
+	}
+	if store.gets != 1 {
+		t.Fatalf("storage gets = %d, want 1", store.gets)
+	}
+}
+
+func TestTestcaseCacheEvictsLeastRecentlyUsedSet(t *testing.T) {
+	firstArchive := testcaseCacheArchive(t, map[string]string{
+		"input1.txt":  "1234",
+		"output1.txt": "5",
+	})
+	secondArchive := testcaseCacheArchive(t, map[string]string{
+		"input1.txt":  "ab",
+		"output1.txt": "cde",
+	})
+	store := &testcaseCacheStorage{objects: map[string][]byte{
+		"first.zip":  firstArchive,
+		"second.zip": secondArchive,
+	}}
+	cache := NewTestcaseCache(store, TestcaseCacheOptions{MaxBytes: 5})
+	firstRef := testcaseCacheRef(firstArchive, 1)
+	firstRef.StorageKey = "first.zip"
+	secondRef := testcaseCacheRef(secondArchive, 2)
+	secondRef.StorageKey = "second.zip"
+
+	if _, err := cache.Load(t.Context(), firstRef); err != nil {
+		t.Fatalf("load first set: %v", err)
+	}
+	if _, err := cache.Load(t.Context(), secondRef); err != nil {
+		t.Fatalf("load second set: %v", err)
+	}
+	if _, err := cache.Load(t.Context(), firstRef); err != nil {
+		t.Fatalf("reload first set: %v", err)
+	}
+	if store.gets != 3 {
+		t.Fatalf("storage gets = %d, want 3 after LRU eviction", store.gets)
+	}
+}
+
+func TestTestcaseCacheRejectsChecksumMismatch(t *testing.T) {
+	archive := testcaseCacheArchive(t, map[string]string{
+		"input1.txt":  "1\n",
+		"output1.txt": "1\n",
+	})
+	store := &testcaseCacheStorage{objects: map[string][]byte{"cases.zip": archive}}
+	cache := NewTestcaseCache(store, TestcaseCacheOptions{MaxBytes: 64})
+	ref := testcaseCacheRef(archive, 3)
+	ref.ChecksumSHA256 = "0000000000000000000000000000000000000000000000000000000000000000"
+
+	if _, err := cache.Load(t.Context(), ref); err == nil {
+		t.Fatal("Load returned nil error for checksum mismatch")
+	}
+	if _, err := cache.Load(t.Context(), ref); err == nil {
+		t.Fatal("second Load returned nil error for checksum mismatch")
+	}
+	if store.gets != 2 {
+		t.Fatalf("storage gets = %d, want 2 because invalid data is not cached", store.gets)
+	}
+}
+
+func testcaseCacheRef(data []byte, id int64) judgeevents.TestcaseSetRef {
+	sum := sha256.Sum256(data)
+	return judgeevents.TestcaseSetRef{
+		ID:             id,
+		ChecksumSHA256: hex.EncodeToString(sum[:]),
+		StorageKey:     "cases.zip",
+		CaseCount:      1,
+		TimeLimitMS:    1000,
+		MemoryKB:       262144,
+	}
+}
+
+func testcaseCacheArchive(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	for name, content := range files {
+		file, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("create testcase entry: %v", err)
+		}
+		if _, err := file.Write([]byte(content)); err != nil {
+			t.Fatalf("write testcase entry: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close testcase archive: %v", err)
+	}
+	return buffer.Bytes()
+}
+
+type testcaseCacheStorage struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+	gets    int
+	delay   time.Duration
+}
+
+func (s *testcaseCacheStorage) Put(context.Context, storage.Object) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, errors.New("not implemented")
+}
+
+func (s *testcaseCacheStorage) Get(_ context.Context, key string) (io.ReadCloser, storage.ObjectInfo, error) {
+	s.mu.Lock()
+	s.gets++
+	delay := s.delay
+	data, ok := s.objects[key]
+	s.mu.Unlock()
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	if !ok {
+		return nil, storage.ObjectInfo{}, errors.New("object not found")
+	}
+	return io.NopCloser(bytes.NewReader(data)), storage.ObjectInfo{Key: key, Size: int64(len(data))}, nil
+}
+
+func (s *testcaseCacheStorage) Delete(context.Context, string) error {
+	return errors.New("not implemented")
+}
+
+func (s *testcaseCacheStorage) Stat(context.Context, string) (storage.ObjectInfo, error) {
+	return storage.ObjectInfo{}, errors.New("not implemented")
+}

--- a/internal/submission/worker.go
+++ b/internal/submission/worker.go
@@ -29,13 +29,14 @@ type taskDispatchStore interface {
 
 type taskDispatchMetrics interface {
 	RecordJudgeTaskDispatch(result string)
+	RecordJudgeRequestPayloadSize(bytes int)
 }
 
 // TaskDispatcher turns pending judge tasks into queue messages.
 type TaskDispatcher struct {
 	store     taskDispatchStore
 	queue     taskPublisher
-	testcases testcaseSnapshotResolver
+	testcases testcaseMetadataResolver
 	metrics   taskDispatchMetrics
 	now       func() time.Time
 	backoff   func(int32) time.Duration
@@ -44,7 +45,7 @@ type TaskDispatcher struct {
 type TaskDispatcherOptions struct {
 	Store            taskDispatchStore
 	Queue            taskPublisher
-	TestcaseResolver testcaseSnapshotResolver
+	TestcaseResolver testcaseMetadataResolver
 	Metrics          taskDispatchMetrics
 	Now              func() time.Time
 	Backoff          func(int32) time.Duration
@@ -87,6 +88,9 @@ func (d *TaskDispatcher) DispatchPending(ctx context.Context, limit int32) (int,
 		if err != nil {
 			return dispatched, err
 		}
+		if d.metrics != nil {
+			d.metrics.RecordJudgeRequestPayloadSize(len(payload))
+		}
 		streamID, err := d.queue.Publish(ctx, task.ID, payload)
 		if err != nil {
 			d.record("error")
@@ -116,19 +120,9 @@ func (d *TaskDispatcher) requestEvent(ctx context.Context, task JudgeTaskRecord)
 	if err != nil {
 		return judgeevents.RequestEvent{}, err
 	}
-	testcaseSet, err := d.testcases.ReadyTestcaseSet(ctx, submission.ProblemID, submission.TestcaseSetID)
+	testcaseSet, err := d.testcases.ReadyTestcaseMetadata(ctx, submission.ProblemID, submission.TestcaseSetID)
 	if err != nil {
 		return judgeevents.RequestEvent{}, err
-	}
-	testcases := make([]judgeevents.TestcaseRef, 0, len(testcaseSet.Cases))
-	for i, testcase := range testcaseSet.Cases {
-		testcases = append(testcases, judgeevents.TestcaseRef{
-			Index:             i + 1,
-			InputKey:          testcase.InputKey,
-			ExpectedOutputKey: testcase.OutputKey,
-			TimeLimitMS:       testcase.TimeLimit.Milliseconds(),
-			MemoryKB:          testcase.MemoryKB,
-		})
 	}
 	now := d.now()
 	if submission.Status == StatusQueued {
@@ -143,7 +137,7 @@ func (d *TaskDispatcher) requestEvent(ctx context.Context, task JudgeTaskRecord)
 		TaskID:          task.ID,
 		LanguageID:      language.ID,
 		TestcaseSetID:   testcaseSet.ID,
-		TestcaseSetHash: fmt.Sprintf("testcase-set-%d", testcaseSet.ID),
+		TestcaseSetHash: testcaseSet.ChecksumSHA256,
 		ProtocolVersion: judgeevents.RequestEventType,
 		JudgeEngine:     judge.EngineSOJAgent,
 		TraceID:         traceID,
@@ -168,10 +162,13 @@ func (d *TaskDispatcher) requestEvent(ctx context.Context, task JudgeTaskRecord)
 			ContentHash: artifact.ChecksumSHA256,
 		},
 		TestcaseSet: judgeevents.TestcaseSetRef{
-			ID:   testcaseSet.ID,
-			Hash: fmt.Sprintf("testcase-set-%d", testcaseSet.ID),
+			ID:             testcaseSet.ID,
+			ChecksumSHA256: testcaseSet.ChecksumSHA256,
+			StorageKey:     testcaseSet.StorageKey,
+			CaseCount:      testcaseSet.CaseCount,
+			TimeLimitMS:    testcaseSet.TimeLimit.Milliseconds(),
+			MemoryKB:       testcaseSet.MemoryKB,
 		},
-		Testcases: testcases,
 		TimeoutMS: language.DefaultTimeLimit.Milliseconds(),
 		MemoryKB:  language.DefaultMemoryKB,
 		Priority:  "formal",
@@ -429,6 +426,10 @@ func (w *Worker) Run(ctx context.Context, limit int, block time.Duration) error 
 
 type testcaseSnapshotResolver interface {
 	ReadyTestcaseSet(ctx context.Context, problemID, testcaseSetID int64) (problem.TestcaseSet, error)
+}
+
+type testcaseMetadataResolver interface {
+	ReadyTestcaseMetadata(ctx context.Context, problemID, testcaseSetID int64) (testcaseMetadata, error)
 }
 
 func traceIdentityFromContext(ctx context.Context, fallback string) (string, judgeevents.TraceContext) {

--- a/internal/submission/worker_ports_test.go
+++ b/internal/submission/worker_ports_test.go
@@ -19,6 +19,10 @@ func (testcaseSnapshotResolverStub) ReadyTestcaseSet(_ context.Context, problemI
 	return problem.TestcaseSet{ID: testcaseSetID, ProblemID: problemID}, nil
 }
 
+func (testcaseSnapshotResolverStub) ReadyTestcaseMetadata(_ context.Context, problemID, testcaseSetID int64) (testcaseMetadata, error) {
+	return testcaseMetadata{ID: testcaseSetID, StorageKey: "cases.zip", ChecksumSHA256: "cases-hash", CaseCount: 1}, nil
+}
+
 type taskPublisherStub struct{}
 
 func (taskPublisherStub) Publish(context.Context, int64, []byte) (string, error) {


### PR DESCRIPTION
## Summary
- publish testcase-set metadata references instead of inline testcase contents
- load and validate testcase archives in judge-agent with bounded LRU and singleflight reuse
- keep the full snapshot path for stale-task recovery and add queue/cache metrics

## Motivation
Every submission previously read and unpacked the testcase archive in the worker and serialized its contents into the Redis request. This change keeps the queue payload small and lets each judge-agent reuse parsed testcase data.

## Validation
- `go test -count=1 ./...`
- `go test -count=1 -race ./internal/submission`
- `go vet ./...`

Fixes #36

## 执行记录
- 2026-08-04：已推送 `perf/issue-36-testcase-queue`，本地测试、race、vet 及 GitHub CI（Backend、Docker Smoke）均通过。