### PR TITLE
refactor(contest): split use-case storage ports

### DIFF
--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -78,7 +78,14 @@ func RunAPI(ctx context.Context, args []string, stdout, stderr io.Writer) error 
 		problem.NewProblemCheckService(problemRepo, objectStorage, time.Now),
 	)
 	contestRepo := contest.NewPostgresRepository(pool)
-	contestService := contest.NewService(contestRepo)
+	contestReader := contest.NewContestReader(contestRepo, time.Now)
+	contestService := contest.NewService(
+		contestReader,
+		contest.NewContestAuthoring(contestRepo, contestReader),
+		contest.NewContestPolicy(contestReader, contestRepo),
+		contest.NewScoreboardService(contestReader, contestRepo),
+		contest.NewScoreboardProjection(contestReader, contestRepo),
+	)
 	submissionRepo := submission.NewSQLRepositoryWithTxRunner(queries, pool)
 	judgeEngine := newJudgeEngine(cfg.Judge)
 	sourceStore := submission.NewObjectSourceStore(objectStorage)

--- a/internal/app/worker.go
+++ b/internal/app/worker.go
@@ -116,7 +116,9 @@ func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) err
 	worker := submission.NewWorker(dispatcher, processor, taskQueue)
 	resultConsumer := submission.NewResultConsumer(submissionRepo)
 	reconciler := submission.NewReconciler(submissionRepo, taskQueue, worker, nil, metrics)
-	contestService := contest.NewService(contest.NewPostgresRepository(pool))
+	contestRepo := contest.NewPostgresRepository(pool)
+	contestReader := contest.NewContestReader(contestRepo, time.Now)
+	scoreboardService := contest.NewScoreboardService(contestReader, contestRepo)
 
 	readiness := newWorkerReadiness(pool.Ping, taskQueue, resultQueue, objectStore, metrics)
 	router := httpapi.NewRouter(httpapi.RouterOptions{
@@ -140,7 +142,7 @@ func RunWorker(ctx context.Context, args []string, stdout, stderr io.Writer) err
 		errCh <- runHTTPServer(runCtx, server, cfg.Worker.ShutdownTimeout)
 	}()
 	go func() {
-		errCh <- runWorkerLoops(runCtx, worker, resultConsumer, taskQueue, resultQueue, reconciler, contestService, metrics, cfg.Redis.BatchSize, cfg.Redis.Block)
+		errCh <- runWorkerLoops(runCtx, worker, resultConsumer, taskQueue, resultQueue, reconciler, scoreboardService, metrics, cfg.Redis.BatchSize, cfg.Redis.Block)
 	}()
 
 	err = <-errCh

--- a/internal/contest/authoring.go
+++ b/internal/contest/authoring.go
@@ -1,0 +1,129 @@
+package contest
+
+import (
+	"context"
+	"strings"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+)
+
+type contestAuthoringStore interface {
+	GetContest(context.Context, int64) (ContestRecord, error)
+	ArchiveContest(context.Context, int64) (ContestRecord, error)
+	WithTx(context.Context, func(context.Context, contestTransaction) error) error
+}
+
+// ContestAuthoring owns contest lifecycle writes and their atomic problem updates.
+type ContestAuthoring struct {
+	store  contestAuthoringStore
+	reader *ContestReader
+}
+
+// NewContestAuthoring builds the contest lifecycle writer.
+func NewContestAuthoring(store contestAuthoringStore, reader *ContestReader) *ContestAuthoring {
+	if store == nil {
+		panic("contest authoring store is required")
+	}
+	if reader == nil {
+		panic("contest authoring reader is required")
+	}
+	return &ContestAuthoring{store: store, reader: reader}
+}
+
+// CreateContest creates a contest and its problem configuration atomically.
+func (a *ContestAuthoring) CreateContest(ctx context.Context, actor auth.Actor, input ContestInput) (ContestRecord, error) {
+	if !actor.Authenticated() {
+		return ContestRecord{}, apperror.Unauthorized("auth_required", "authentication required")
+	}
+	if input.Status == "" {
+		input.Status = StatusDraft
+	}
+	if err := validateContestInput(input); err != nil {
+		return ContestRecord{}, err
+	}
+	problems, err := contestProblems(0, input.Problems)
+	if err != nil {
+		return ContestRecord{}, err
+	}
+	record := ContestRecord{
+		OwnerUserID:    actor.UserID,
+		Title:          strings.TrimSpace(input.Title),
+		Description:    input.Description,
+		Visibility:     input.Visibility,
+		Status:         input.Status,
+		StartAt:        input.StartAt.UTC(),
+		EndAt:          input.EndAt.UTC(),
+		FreezeAt:       input.FreezeAt.UTC(),
+		InviteCodeHash: hashInviteCode(input.InviteCode),
+	}
+
+	var created ContestRecord
+	err = a.store.WithTx(ctx, func(ctx context.Context, tx contestTransaction) error {
+		var err error
+		created, err = tx.CreateContest(ctx, record)
+		if err != nil {
+			return err
+		}
+		for i := range problems {
+			problems[i].ContestID = created.ID
+		}
+		if err := tx.ReplaceContestProblems(ctx, created.ID, problems); err != nil {
+			return err
+		}
+		created.Problems = problems
+		return nil
+	})
+	created.ScoringMode = ScoringModeACM
+	return created, err
+}
+
+// UpdateContest updates a contest and replaces its problem configuration atomically.
+func (a *ContestAuthoring) UpdateContest(ctx context.Context, actor auth.Actor, id int64, input ContestUpdateInput) (ContestRecord, error) {
+	current, err := a.store.GetContest(ctx, id)
+	if err != nil {
+		return ContestRecord{}, err
+	}
+	if err := requireContestWriter(actor, current); err != nil {
+		return ContestRecord{}, err
+	}
+	if err := validateContestUpdate(current, input); err != nil {
+		return ContestRecord{}, err
+	}
+	var updated ContestRecord
+	err = a.store.WithTx(ctx, func(ctx context.Context, tx contestTransaction) error {
+		var err error
+		updated, err = tx.UpdateContest(ctx, id, input)
+		if err != nil {
+			return err
+		}
+		if input.Problems != nil {
+			problems, err := contestProblems(id, *input.Problems)
+			if err != nil {
+				return err
+			}
+			if err := tx.ReplaceContestProblems(ctx, id, problems); err != nil {
+				return err
+			}
+			updated.Problems = problems
+			updated.ScoringMode = ScoringModeACM
+			updated.Registered = a.reader.actorRegisteredForContest(ctx, actor, updated.ID)
+			return nil
+		}
+		updated, err = a.reader.withFrontendContract(ctx, actor, updated)
+		return err
+	})
+	return updated, err
+}
+
+// DeleteContest archives a contest after checking ownership.
+func (a *ContestAuthoring) DeleteContest(ctx context.Context, actor auth.Actor, id int64) (ContestRecord, error) {
+	current, err := a.store.GetContest(ctx, id)
+	if err != nil {
+		return ContestRecord{}, err
+	}
+	if err := requireContestWriter(actor, current); err != nil {
+		return ContestRecord{}, err
+	}
+	return a.store.ArchiveContest(ctx, id)
+}

--- a/internal/contest/memory_repository_test.go
+++ b/internal/contest/memory_repository_test.go
@@ -37,7 +37,7 @@ func (r *memoryRepository) id() int64 {
 	return r.nextID
 }
 
-func (r *memoryRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
+func (r *memoryRepository) WithTx(ctx context.Context, fn func(context.Context, contestTransaction) error) error {
 	return fn(ctx, r)
 }
 

--- a/internal/contest/policy.go
+++ b/internal/contest/policy.go
@@ -1,0 +1,174 @@
+package contest
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+	"SOJ/internal/submission"
+)
+
+type contestRegistrationWriter interface {
+	CreateRegistration(context.Context, ContestRegistration) (ContestRegistration, error)
+}
+
+// ContestPolicy owns registration, submission admission, and result visibility rules.
+type ContestPolicy struct {
+	reader        *ContestReader
+	registrations contestRegistrationWriter
+}
+
+// NewContestPolicy builds contest policies with their registration writer.
+func NewContestPolicy(reader *ContestReader, registrations contestRegistrationWriter) *ContestPolicy {
+	if reader == nil {
+		panic("contest policy reader is required")
+	}
+	if registrations == nil {
+		panic("contest registration writer is required")
+	}
+	return &ContestPolicy{reader: reader, registrations: registrations}
+}
+
+// AuthorizeContestRejudge checks whether an actor may rejudge a contest.
+func (p *ContestPolicy) AuthorizeContestRejudge(ctx context.Context, actor auth.Actor, id int64) error {
+	contest, err := p.reader.getContest(ctx, id)
+	if err != nil {
+		return err
+	}
+	return requireContestWriter(actor, contest)
+}
+
+// ValidateContestRejudgeTarget checks whether a contest is ended and rejudgeable.
+func (p *ContestPolicy) ValidateContestRejudgeTarget(ctx context.Context, id int64) error {
+	contest, err := p.reader.getContest(ctx, id)
+	if err != nil {
+		return err
+	}
+	if contest.Status != StatusEnded {
+		return apperror.Conflict("rejudge.contest_not_ended", "contest must be ended before rejudge")
+	}
+	return nil
+}
+
+// Register registers an authenticated actor for a contest.
+func (p *ContestPolicy) Register(ctx context.Context, actor auth.Actor, contestID int64, input RegistrationInput) (ContestRegistration, error) {
+	if !actor.Authenticated() {
+		return ContestRegistration{}, apperror.Unauthorized("auth_required", "authentication required")
+	}
+	contest, err := p.reader.getContest(ctx, contestID)
+	if err != nil {
+		return ContestRegistration{}, err
+	}
+	if contest.Visibility == VisibilityPrivate && contest.InviteCodeHash == "" {
+		return ContestRegistration{}, apperror.Forbidden("contest.invite_code_required", "invite code is required")
+	}
+	if contest.Visibility == VisibilityPrivate && contest.InviteCodeHash != hashInviteCode(input.InviteCode) {
+		return ContestRegistration{}, apperror.Forbidden("contest.invite_code_invalid", "invite code is invalid")
+	}
+	displayName := strings.TrimSpace(input.DisplayName)
+	email := strings.TrimSpace(input.Email)
+	if displayName == "" || email == "" {
+		return ContestRegistration{}, apperror.BadRequest("request.invalid", "display_name and email are required")
+	}
+	return p.registrations.CreateRegistration(ctx, ContestRegistration{
+		ContestID:   contestID,
+		UserID:      actor.UserID,
+		DisplayName: displayName,
+		Email:       email,
+		Status:      RegistrationActive,
+	})
+}
+
+// ValidateSubmission checks contest admission for a submission.
+func (p *ContestPolicy) ValidateSubmission(ctx context.Context, actor auth.Actor, problemID, contestID int64) error {
+	if !actor.Authenticated() {
+		return apperror.Unauthorized("auth_required", "authentication required")
+	}
+	contest, err := p.reader.getContest(ctx, contestID)
+	if err != nil {
+		return err
+	}
+	if contest.Status != StatusPublished && contest.Status != StatusRunning {
+		return apperror.Forbidden("contest.not_started", "contest is not accepting submissions")
+	}
+	now := p.reader.now()
+	if now.Before(contest.StartAt) {
+		return apperror.Forbidden("contest.not_started", "contest has not started")
+	}
+	if !now.Before(contest.EndAt) {
+		return apperror.Forbidden("contest.ended", "contest has ended")
+	}
+	problems, err := p.reader.listContestProblems(ctx, contestID)
+	if err != nil {
+		return err
+	}
+	if !containsProblem(problems, problemID) {
+		return apperror.NotFound("contest.problem_not_found", "problem is not in contest")
+	}
+	if actor.Admin() || actor.UserID == contest.OwnerUserID {
+		return nil
+	}
+	registration, err := p.reader.getRegistration(ctx, contestID, actor.UserID)
+	if err != nil || registration.Status != RegistrationActive {
+		return apperror.Forbidden("contest.registration_required", "contest registration required")
+	}
+	return nil
+}
+
+// SubmissionResultVisibility applies contest freeze visibility to one submission.
+func (p *ContestPolicy) SubmissionResultVisibility(ctx context.Context, actor auth.Actor, sub submission.ContestSubmissionVisibility) (submission.SubmissionResultVisibility, error) {
+	contest, err := p.reader.getContest(ctx, sub.ContestID)
+	if err != nil {
+		return submission.SubmissionResultVisibility{}, err
+	}
+	if err := p.reader.canReadContest(ctx, actor, contest); err != nil {
+		return submission.SubmissionResultVisibility{}, err
+	}
+	return submissionResultVisibility(contest, actor, sub, p.reader.now()), nil
+}
+
+// SubmissionResultVisibilities applies contest freeze visibility to many submissions.
+func (p *ContestPolicy) SubmissionResultVisibilities(ctx context.Context, actor auth.Actor, submissions []submission.ContestSubmissionVisibility) (map[int64]submission.SubmissionResultVisibility, error) {
+	visibilities := make(map[int64]submission.SubmissionResultVisibility, len(submissions))
+	contests := make(map[int64]ContestRecord)
+	now := p.reader.now()
+	for _, sub := range submissions {
+		contest, ok := contests[sub.ContestID]
+		if !ok {
+			var err error
+			contest, err = p.reader.getContest(ctx, sub.ContestID)
+			if err != nil {
+				return nil, err
+			}
+			if err := p.reader.canReadContest(ctx, actor, contest); err != nil {
+				return nil, err
+			}
+			contests[sub.ContestID] = contest
+		}
+		visibilities[sub.ID] = submissionResultVisibility(contest, actor, sub, now)
+	}
+	return visibilities, nil
+}
+
+func submissionResultVisibility(contest ContestRecord, actor auth.Actor, sub submission.ContestSubmissionVisibility, now time.Time) submission.SubmissionResultVisibility {
+	if actor.Admin() || actor.UserID == contest.OwnerUserID {
+		return submission.SubmissionResultVisibility{ShowResult: true, ShowCases: true, ShowAdminDiagnostics: true, Visibility: "visible"}
+	}
+	visible := submissionVisibleInFrozenWindow(contest, sub, now)
+	if !visible {
+		return submission.SubmissionResultVisibility{Visibility: "frozen"}
+	}
+	return submission.SubmissionResultVisibility{ShowResult: true, ShowCases: true, Visibility: "visible"}
+}
+
+func submissionVisibleInFrozenWindow(contest ContestRecord, sub submission.ContestSubmissionVisibility, now time.Time) bool {
+	if now.Before(contest.FreezeAt) || !now.Before(contest.EndAt) {
+		return true
+	}
+	if sub.JudgedAt == nil {
+		return sub.SubmittedAt.Before(contest.FreezeAt)
+	}
+	return sub.SubmittedAt.Before(contest.FreezeAt) && !sub.JudgedAt.After(contest.FreezeAt)
+}

--- a/internal/contest/reader.go
+++ b/internal/contest/reader.go
@@ -1,0 +1,172 @@
+package contest
+
+import (
+	"context"
+	"time"
+
+	"SOJ/internal/apperror"
+	"SOJ/internal/auth"
+)
+
+type contestReaderStore interface {
+	GetContest(context.Context, int64) (ContestRecord, error)
+	ListContests(context.Context, ListContestFilter) ([]ContestRecord, int64, error)
+	ListContestsByCursor(context.Context, ListContestFilter) ([]ContestRecord, error)
+	ListContestProblems(context.Context, int64) ([]ContestProblem, error)
+	GetRegistration(context.Context, int64, int64) (ContestRegistration, error)
+	ListRegistrations(context.Context, int64) ([]ContestRegistration, error)
+}
+
+// ContestReader serves contest catalog and access-controlled read workflows.
+type ContestReader struct {
+	store contestReaderStore
+	now   func() time.Time
+}
+
+// NewContestReader builds a contest reader with its read store and clock.
+func NewContestReader(store contestReaderStore, now func() time.Time) *ContestReader {
+	if store == nil {
+		panic("contest reader store is required")
+	}
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &ContestReader{store: store, now: now}
+}
+
+// GetContest returns a contest after applying viewer access and frontend fields.
+func (r *ContestReader) GetContest(ctx context.Context, actor auth.Actor, id int64) (ContestRecord, error) {
+	record, err := r.getContest(ctx, id)
+	if err != nil {
+		return ContestRecord{}, err
+	}
+	if err := r.canReadContest(ctx, actor, record); err != nil {
+		return ContestRecord{}, err
+	}
+	return r.withFrontendContract(ctx, actor, record)
+}
+
+// ListContests returns a page of contests visible to the actor.
+func (r *ContestReader) ListContests(ctx context.Context, actor auth.Actor, filter ListContestFilter) (ContestList, error) {
+	if filter.Page <= 0 {
+		filter.Page = 1
+	}
+	if filter.PageSize <= 0 || filter.PageSize > 100 {
+		filter.PageSize = 20
+	}
+	if actor.Admin() {
+		filter.IncludePrivate = true
+	} else if actor.Authenticated() {
+		filter.VisibleToUserID = actor.UserID
+	}
+	filter.Limit = filter.PageSize
+	filter.Offset = (filter.Page - 1) * filter.PageSize
+	items, total, err := r.store.ListContests(ctx, filter)
+	if err != nil {
+		return ContestList{}, err
+	}
+	for i := range items {
+		withProblems, err := r.withFrontendContract(ctx, actor, items[i])
+		if err != nil {
+			return ContestList{}, err
+		}
+		items[i] = withProblems
+	}
+	return ContestList{Items: items, Total: total, Page: filter.Page, PageSize: filter.PageSize}, nil
+}
+
+// ListContestsByCursor returns a cursor page of contests visible to the actor.
+func (r *ContestReader) ListContestsByCursor(ctx context.Context, actor auth.Actor, filter ListContestFilter) (ContestCursorPage, error) {
+	if filter.PageSize <= 0 || filter.PageSize > 100 {
+		filter.PageSize = 20
+	}
+	if actor.Admin() {
+		filter.IncludePrivate = true
+	} else if actor.Authenticated() {
+		filter.VisibleToUserID = actor.UserID
+	}
+	limit := filter.PageSize
+	cursor := ContestCursor{
+		StartAt: time.Date(9999, time.December, 31, 23, 59, 59, 999999999, time.UTC),
+		ID:      1<<63 - 1,
+	}
+	if filter.Cursor != nil {
+		if filter.Cursor.ID <= 0 || filter.Cursor.StartAt.IsZero() {
+			return ContestCursorPage{}, apperror.BadRequest("invalid_cursor", "cursor is invalid")
+		}
+		cursor = ContestCursor{StartAt: filter.Cursor.StartAt.UTC(), ID: filter.Cursor.ID}
+	}
+	filter.Cursor = &cursor
+	filter.Limit = limit + 1
+	filter.Offset = 0
+	items, err := r.store.ListContestsByCursor(ctx, filter)
+	if err != nil {
+		return ContestCursorPage{}, err
+	}
+	hasMore := len(items) > int(limit)
+	if hasMore {
+		items = items[:limit]
+	}
+	for i := range items {
+		withProblems, err := r.withFrontendContract(ctx, actor, items[i])
+		if err != nil {
+			return ContestCursorPage{}, err
+		}
+		items[i] = withProblems
+	}
+	page := ContestCursorPage{Items: items}
+	if hasMore {
+		last := items[len(items)-1]
+		page.NextCursor = &ContestCursor{StartAt: last.StartAt, ID: last.ID}
+	}
+	return page, nil
+}
+
+func (r *ContestReader) getContest(ctx context.Context, id int64) (ContestRecord, error) {
+	return r.store.GetContest(ctx, id)
+}
+
+func (r *ContestReader) listContestProblems(ctx context.Context, contestID int64) ([]ContestProblem, error) {
+	return r.store.ListContestProblems(ctx, contestID)
+}
+
+func (r *ContestReader) listRegistrations(ctx context.Context, contestID int64) ([]ContestRegistration, error) {
+	return r.store.ListRegistrations(ctx, contestID)
+}
+
+func (r *ContestReader) getRegistration(ctx context.Context, contestID, userID int64) (ContestRegistration, error) {
+	return r.store.GetRegistration(ctx, contestID, userID)
+}
+
+func (r *ContestReader) withFrontendContract(ctx context.Context, actor auth.Actor, record ContestRecord) (ContestRecord, error) {
+	problems, err := r.listContestProblems(ctx, record.ID)
+	if err != nil {
+		return ContestRecord{}, err
+	}
+	record.Problems = problems
+	record.ScoringMode = ScoringModeACM
+	record.Registered = r.actorRegisteredForContest(ctx, actor, record.ID)
+	return record, nil
+}
+
+func (r *ContestReader) actorRegisteredForContest(ctx context.Context, actor auth.Actor, contestID int64) bool {
+	if !actor.Authenticated() {
+		return false
+	}
+	registration, err := r.getRegistration(ctx, contestID, actor.UserID)
+	return err == nil && registration.Status == RegistrationActive
+}
+
+func (r *ContestReader) canReadContest(ctx context.Context, actor auth.Actor, contest ContestRecord) error {
+	if contest.Visibility == VisibilityPublic || actor.Admin() || actor.UserID == contest.OwnerUserID {
+		return nil
+	}
+	if !actor.Authenticated() {
+		return apperror.Unauthorized("auth_required", "authentication required")
+	}
+	registration, err := r.getRegistration(ctx, contest.ID, actor.UserID)
+	if err == nil && registration.Status == RegistrationActive {
+		return nil
+	}
+	return apperror.Forbidden("contest.not_allowed", "contest access denied")
+}

--- a/internal/contest/repository.go
+++ b/internal/contest/repository.go
@@ -16,27 +16,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-type Repository interface {
-	WithTx(ctx context.Context, fn func(context.Context, Repository) error) error
-	CreateContest(ctx context.Context, input ContestRecord) (ContestRecord, error)
-	GetContest(ctx context.Context, id int64) (ContestRecord, error)
-	ListContests(ctx context.Context, filter ListContestFilter) ([]ContestRecord, int64, error)
-	ListContestsByCursor(ctx context.Context, filter ListContestFilter) ([]ContestRecord, error)
-	UpdateContest(ctx context.Context, id int64, input ContestUpdateInput) (ContestRecord, error)
-	ArchiveContest(ctx context.Context, id int64) (ContestRecord, error)
-	ReplaceContestProblems(ctx context.Context, contestID int64, problems []ContestProblem) error
-	ListContestProblems(ctx context.Context, contestID int64) ([]ContestProblem, error)
-	CreateRegistration(ctx context.Context, input ContestRegistration) (ContestRegistration, error)
-	GetRegistration(ctx context.Context, contestID, userID int64) (ContestRegistration, error)
-	ListRegistrations(ctx context.Context, contestID int64) ([]ContestRegistration, error)
-	ListProblemResults(ctx context.Context, contestID int64) ([]ContestProblemResult, error)
-	ListTerminalSubmissions(ctx context.Context, contestID int64) ([]ContestSubmissionResult, error)
-	UpsertProblemResult(ctx context.Context, result ContestProblemResult) (ContestProblemResult, error)
-	ListScoreSnapshotCandidates(ctx context.Context, now time.Time, limit int32) ([]ScoreSnapshotCandidate, error)
-	CreateScoreSnapshot(ctx context.Context, snapshot ScoreboardSnapshot) (ScoreboardSnapshot, error)
-	LatestScoreSnapshot(ctx context.Context, contestID int64, view ScoreboardView) (ScoreboardSnapshot, error)
-}
-
 type PostgresRepository struct {
 	pool    *pgxpool.Pool
 	queries *db.Queries
@@ -46,7 +25,7 @@ func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
 	return &PostgresRepository{pool: pool, queries: db.New(pool)}
 }
 
-func (r *PostgresRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
+func (r *PostgresRepository) WithTx(ctx context.Context, fn func(context.Context, contestTransaction) error) error {
 	return postgres.WithPoolTx(ctx, r.pool, func(tx pgx.Tx) error {
 		return fn(ctx, &txRepository{queries: r.queries.WithTx(tx)})
 	})
@@ -127,7 +106,7 @@ type txRepository struct {
 	queries *db.Queries
 }
 
-func (r *txRepository) WithTx(ctx context.Context, fn func(context.Context, Repository) error) error {
+func (r *txRepository) WithTx(ctx context.Context, fn func(context.Context, contestTransaction) error) error {
 	return fn(ctx, r)
 }
 

--- a/internal/contest/scoreboard.go
+++ b/internal/contest/scoreboard.go
@@ -39,12 +39,38 @@ type ScoreboardCell struct {
 	LastSubmissionID *int64     `json:"last_submission_id,omitempty"`
 }
 
-func (s *Service) Scoreboard(ctx context.Context, actor auth.Actor, contestID int64, requested ScoreboardView) (ScoreboardResponse, error) {
-	contest, err := s.repo.GetContest(ctx, contestID)
+type scoreboardStore interface {
+	ListProblemResults(context.Context, int64) ([]ContestProblemResult, error)
+	ListTerminalSubmissions(context.Context, int64) ([]ContestSubmissionResult, error)
+	ListScoreSnapshotCandidates(context.Context, time.Time, int32) ([]ScoreSnapshotCandidate, error)
+	CreateScoreSnapshot(context.Context, ScoreboardSnapshot) (ScoreboardSnapshot, error)
+	LatestScoreSnapshot(context.Context, int64, ScoreboardView) (ScoreboardSnapshot, error)
+}
+
+// ScoreboardService owns scoreboard reads and snapshot generation.
+type ScoreboardService struct {
+	reader *ContestReader
+	store  scoreboardStore
+}
+
+// NewScoreboardService builds scoreboard workflows from contest reads and score storage.
+func NewScoreboardService(reader *ContestReader, store scoreboardStore) *ScoreboardService {
+	if reader == nil {
+		panic("scoreboard reader is required")
+	}
+	if store == nil {
+		panic("scoreboard store is required")
+	}
+	return &ScoreboardService{reader: reader, store: store}
+}
+
+// Scoreboard returns the requested contest scoreboard view.
+func (s *ScoreboardService) Scoreboard(ctx context.Context, actor auth.Actor, contestID int64, requested ScoreboardView) (ScoreboardResponse, error) {
+	contest, err := s.reader.getContest(ctx, contestID)
 	if err != nil {
 		return ScoreboardResponse{}, err
 	}
-	if err := s.canReadContest(ctx, actor, contest); err != nil {
+	if err := s.reader.canReadContest(ctx, actor, contest); err != nil {
 		return ScoreboardResponse{}, err
 	}
 	view := s.defaultScoreboardView(contest, requested)
@@ -52,7 +78,7 @@ func (s *Service) Scoreboard(ctx context.Context, actor auth.Actor, contestID in
 		return ScoreboardResponse{}, err
 	}
 	if view == ScoreboardViewFinal || view == ScoreboardViewFrozen {
-		snapshot, err := s.repo.LatestScoreSnapshot(ctx, contestID, view)
+		snapshot, err := s.store.LatestScoreSnapshot(ctx, contestID, view)
 		if err == nil {
 			return snapshot.Board, nil
 		}
@@ -61,14 +87,15 @@ func (s *Service) Scoreboard(ctx context.Context, actor auth.Actor, contestID in
 			return ScoreboardResponse{}, err
 		}
 	}
-	return s.buildScoreboard(ctx, contest, view, s.now())
+	return s.buildScoreboard(ctx, contest, view, s.reader.now())
 }
 
-func (s *Service) GenerateDueScoreSnapshots(ctx context.Context, limit int32) (ScoreSnapshotGenerationResult, error) {
+// GenerateDueScoreSnapshots builds missing frozen and final snapshots.
+func (s *ScoreboardService) GenerateDueScoreSnapshots(ctx context.Context, limit int32) (ScoreSnapshotGenerationResult, error) {
 	if limit <= 0 {
 		limit = 100
 	}
-	candidates, err := s.repo.ListScoreSnapshotCandidates(ctx, s.now(), limit)
+	candidates, err := s.store.ListScoreSnapshotCandidates(ctx, s.reader.now(), limit)
 	if err != nil {
 		return ScoreSnapshotGenerationResult{}, err
 	}
@@ -77,12 +104,12 @@ func (s *Service) GenerateDueScoreSnapshots(ctx context.Context, limit int32) (S
 		if candidate.View != ScoreboardViewFrozen && candidate.View != ScoreboardViewFinal {
 			continue
 		}
-		generatedAt := s.now()
+		generatedAt := s.reader.now()
 		board, err := s.buildScoreboard(ctx, candidate.Contest, candidate.View, generatedAt)
 		if err != nil {
 			return result, err
 		}
-		if _, err := s.repo.CreateScoreSnapshot(ctx, ScoreboardSnapshot{
+		if _, err := s.store.CreateScoreSnapshot(ctx, ScoreboardSnapshot{
 			ContestID:   candidate.Contest.ID,
 			View:        candidate.View,
 			Board:       board,
@@ -100,17 +127,17 @@ func (s *Service) GenerateDueScoreSnapshots(ctx context.Context, limit int32) (S
 	return result, nil
 }
 
-func (s *Service) buildScoreboard(ctx context.Context, contest ContestRecord, view ScoreboardView, generatedAt time.Time) (ScoreboardResponse, error) {
-	problems, err := s.repo.ListContestProblems(ctx, contest.ID)
+func (s *ScoreboardService) buildScoreboard(ctx context.Context, contest ContestRecord, view ScoreboardView, generatedAt time.Time) (ScoreboardResponse, error) {
+	problems, err := s.reader.listContestProblems(ctx, contest.ID)
 	if err != nil {
 		return ScoreboardResponse{}, err
 	}
-	registrations, err := s.repo.ListRegistrations(ctx, contest.ID)
+	registrations, err := s.reader.listRegistrations(ctx, contest.ID)
 	if err != nil {
 		return ScoreboardResponse{}, err
 	}
 	if view == ScoreboardViewFrozen {
-		submissions, err := s.repo.ListTerminalSubmissions(ctx, contest.ID)
+		submissions, err := s.store.ListTerminalSubmissions(ctx, contest.ID)
 		if err != nil {
 			return ScoreboardResponse{}, err
 		}
@@ -118,18 +145,18 @@ func (s *Service) buildScoreboard(ctx context.Context, contest ContestRecord, vi
 			return buildBoardFromSubmissions(contest, view, problems, registrations, submissions, generatedAt), nil
 		}
 	}
-	results, err := s.repo.ListProblemResults(ctx, contest.ID)
+	results, err := s.store.ListProblemResults(ctx, contest.ID)
 	if err != nil {
 		return ScoreboardResponse{}, err
 	}
 	return buildBoardFromResults(contest, view, problems, registrations, results, generatedAt), nil
 }
 
-func (s *Service) defaultScoreboardView(contest ContestRecord, requested ScoreboardView) ScoreboardView {
+func (s *ScoreboardService) defaultScoreboardView(contest ContestRecord, requested ScoreboardView) ScoreboardView {
 	if requested != "" {
 		return requested
 	}
-	now := s.now()
+	now := s.reader.now()
 	if !now.Before(contest.EndAt) {
 		return ScoreboardViewFinal
 	}
@@ -139,8 +166,8 @@ func (s *Service) defaultScoreboardView(contest ContestRecord, requested Scorebo
 	return ScoreboardViewLive
 }
 
-func (s *Service) canViewScoreboard(actor auth.Actor, contest ContestRecord, view ScoreboardView) error {
-	now := s.now()
+func (s *ScoreboardService) canViewScoreboard(actor auth.Actor, contest ContestRecord, view ScoreboardView) error {
+	now := s.reader.now()
 	switch view {
 	case ScoreboardViewLive:
 		if now.Before(contest.FreezeAt) || actor.Admin() || actor.UserID == contest.OwnerUserID {

--- a/internal/contest/service.go
+++ b/internal/contest/service.go
@@ -182,382 +182,98 @@ type ContestCursorPage struct {
 	NextCursor *ContestCursor  `json:"next_cursor,omitempty"`
 }
 
+type contestTransaction interface {
+	CreateContest(context.Context, ContestRecord) (ContestRecord, error)
+	UpdateContest(context.Context, int64, ContestUpdateInput) (ContestRecord, error)
+	ReplaceContestProblems(context.Context, int64, []ContestProblem) error
+}
+
 type Service struct {
-	repo Repository
-	now  func() time.Time
+	authoring  *ContestAuthoring
+	reader     *ContestReader
+	policy     *ContestPolicy
+	scoreboard *ScoreboardService
+	projection *ScoreboardProjection
 }
 
-type Option func(*Service)
-
-func WithNow(now func() time.Time) Option {
-	return func(s *Service) {
-		if now != nil {
-			s.now = now
-		}
+// NewService composes the public contest API from focused workflows.
+func NewService(reader *ContestReader, authoring *ContestAuthoring, policy *ContestPolicy, scoreboard *ScoreboardService, projection *ScoreboardProjection) *Service {
+	if reader == nil {
+		panic("contest reader is required")
 	}
-}
-
-func NewService(repo Repository, options ...Option) *Service {
-	s := &Service{repo: repo, now: func() time.Time { return time.Now().UTC() }}
-	for _, option := range options {
-		option(s)
+	if authoring == nil {
+		panic("contest authoring is required")
 	}
-	return s
+	if policy == nil {
+		panic("contest policy is required")
+	}
+	if scoreboard == nil {
+		panic("contest scoreboard is required")
+	}
+	if projection == nil {
+		panic("contest projection is required")
+	}
+	return &Service{authoring: authoring, reader: reader, policy: policy, scoreboard: scoreboard, projection: projection}
 }
 
 func (s *Service) CreateContest(ctx context.Context, actor auth.Actor, input ContestInput) (ContestRecord, error) {
-	if !actor.Authenticated() {
-		return ContestRecord{}, apperror.Unauthorized("auth_required", "authentication required")
-	}
-	if input.Status == "" {
-		input.Status = StatusDraft
-	}
-	if err := validateContestInput(input); err != nil {
-		return ContestRecord{}, err
-	}
-	problems, err := contestProblems(0, input.Problems)
-	if err != nil {
-		return ContestRecord{}, err
-	}
-	record := ContestRecord{
-		OwnerUserID:    actor.UserID,
-		Title:          strings.TrimSpace(input.Title),
-		Description:    input.Description,
-		Visibility:     input.Visibility,
-		Status:         input.Status,
-		StartAt:        input.StartAt.UTC(),
-		EndAt:          input.EndAt.UTC(),
-		FreezeAt:       input.FreezeAt.UTC(),
-		InviteCodeHash: hashInviteCode(input.InviteCode),
-	}
-
-	var created ContestRecord
-	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		var err error
-		created, err = repo.CreateContest(ctx, record)
-		if err != nil {
-			return err
-		}
-		for i := range problems {
-			problems[i].ContestID = created.ID
-		}
-		if err := repo.ReplaceContestProblems(ctx, created.ID, problems); err != nil {
-			return err
-		}
-		created.Problems = problems
-		return nil
-	})
-	created.ScoringMode = ScoringModeACM
-	return created, err
+	return s.authoring.CreateContest(ctx, actor, input)
 }
 
 func (s *Service) GetContest(ctx context.Context, actor auth.Actor, id int64) (ContestRecord, error) {
-	record, err := s.repo.GetContest(ctx, id)
-	if err != nil {
-		return ContestRecord{}, err
-	}
-	if err := s.canReadContest(ctx, actor, record); err != nil {
-		return ContestRecord{}, err
-	}
-	return s.withFrontendContract(ctx, actor, record)
+	return s.reader.GetContest(ctx, actor, id)
 }
 
 func (s *Service) ListContests(ctx context.Context, actor auth.Actor, filter ListContestFilter) (ContestList, error) {
-	if filter.Page <= 0 {
-		filter.Page = 1
-	}
-	if filter.PageSize <= 0 || filter.PageSize > 100 {
-		filter.PageSize = 20
-	}
-	if actor.Admin() {
-		filter.IncludePrivate = true
-	} else if actor.Authenticated() {
-		filter.VisibleToUserID = actor.UserID
-	}
-	filter.Limit = filter.PageSize
-	filter.Offset = (filter.Page - 1) * filter.PageSize
-	items, total, err := s.repo.ListContests(ctx, filter)
-	if err != nil {
-		return ContestList{}, err
-	}
-	for i := range items {
-		withProblems, err := s.withFrontendContract(ctx, actor, items[i])
-		if err != nil {
-			return ContestList{}, err
-		}
-		items[i] = withProblems
-	}
-	return ContestList{Items: items, Total: total, Page: filter.Page, PageSize: filter.PageSize}, nil
+	return s.reader.ListContests(ctx, actor, filter)
 }
 
 func (s *Service) ListContestsByCursor(ctx context.Context, actor auth.Actor, filter ListContestFilter) (ContestCursorPage, error) {
-	if filter.PageSize <= 0 || filter.PageSize > 100 {
-		filter.PageSize = 20
-	}
-	if actor.Admin() {
-		filter.IncludePrivate = true
-	} else if actor.Authenticated() {
-		filter.VisibleToUserID = actor.UserID
-	}
-	limit := filter.PageSize
-	cursor := ContestCursor{
-		StartAt: time.Date(9999, time.December, 31, 23, 59, 59, 999999999, time.UTC),
-		ID:      1<<63 - 1,
-	}
-	if filter.Cursor != nil {
-		if filter.Cursor.ID <= 0 || filter.Cursor.StartAt.IsZero() {
-			return ContestCursorPage{}, apperror.BadRequest("invalid_cursor", "cursor is invalid")
-		}
-		cursor = ContestCursor{StartAt: filter.Cursor.StartAt.UTC(), ID: filter.Cursor.ID}
-	}
-	filter.Cursor = &cursor
-	filter.Limit = limit + 1
-	filter.Offset = 0
-	items, err := s.repo.ListContestsByCursor(ctx, filter)
-	if err != nil {
-		return ContestCursorPage{}, err
-	}
-	hasMore := len(items) > int(limit)
-	if hasMore {
-		items = items[:limit]
-	}
-	for i := range items {
-		withProblems, err := s.withFrontendContract(ctx, actor, items[i])
-		if err != nil {
-			return ContestCursorPage{}, err
-		}
-		items[i] = withProblems
-	}
-	page := ContestCursorPage{Items: items}
-	if hasMore {
-		last := items[len(items)-1]
-		page.NextCursor = &ContestCursor{StartAt: last.StartAt, ID: last.ID}
-	}
-	return page, nil
+	return s.reader.ListContestsByCursor(ctx, actor, filter)
 }
 
 func (s *Service) UpdateContest(ctx context.Context, actor auth.Actor, id int64, input ContestUpdateInput) (ContestRecord, error) {
-	current, err := s.repo.GetContest(ctx, id)
-	if err != nil {
-		return ContestRecord{}, err
-	}
-	if err := requireContestWriter(actor, current); err != nil {
-		return ContestRecord{}, err
-	}
-	if err := validateContestUpdate(current, input); err != nil {
-		return ContestRecord{}, err
-	}
-	var updated ContestRecord
-	err = s.repo.WithTx(ctx, func(ctx context.Context, repo Repository) error {
-		var err error
-		updated, err = repo.UpdateContest(ctx, id, input)
-		if err != nil {
-			return err
-		}
-		if input.Problems != nil {
-			problems, err := contestProblems(id, *input.Problems)
-			if err != nil {
-				return err
-			}
-			if err := repo.ReplaceContestProblems(ctx, id, problems); err != nil {
-				return err
-			}
-			updated.Problems = problems
-			updated.ScoringMode = ScoringModeACM
-			updated.Registered = s.actorRegisteredForContest(ctx, actor, updated.ID)
-			return nil
-		}
-		updated, err = s.withFrontendContract(ctx, actor, updated)
-		return err
-	})
-	return updated, err
+	return s.authoring.UpdateContest(ctx, actor, id, input)
 }
 
 func (s *Service) DeleteContest(ctx context.Context, actor auth.Actor, id int64) (ContestRecord, error) {
-	current, err := s.repo.GetContest(ctx, id)
-	if err != nil {
-		return ContestRecord{}, err
-	}
-	if err := requireContestWriter(actor, current); err != nil {
-		return ContestRecord{}, err
-	}
-	return s.repo.ArchiveContest(ctx, id)
+	return s.authoring.DeleteContest(ctx, actor, id)
 }
 
 func (s *Service) AuthorizeContestRejudge(ctx context.Context, actor auth.Actor, id int64) error {
-	contest, err := s.repo.GetContest(ctx, id)
-	if err != nil {
-		return err
-	}
-	return requireContestWriter(actor, contest)
+	return s.policy.AuthorizeContestRejudge(ctx, actor, id)
 }
 
 func (s *Service) ValidateContestRejudgeTarget(ctx context.Context, id int64) error {
-	contest, err := s.repo.GetContest(ctx, id)
-	if err != nil {
-		return err
-	}
-	if contest.Status != StatusEnded {
-		return apperror.Conflict("rejudge.contest_not_ended", "contest must be ended before rejudge")
-	}
-	return nil
+	return s.policy.ValidateContestRejudgeTarget(ctx, id)
 }
 
 func (s *Service) Register(ctx context.Context, actor auth.Actor, contestID int64, input RegistrationInput) (ContestRegistration, error) {
-	if !actor.Authenticated() {
-		return ContestRegistration{}, apperror.Unauthorized("auth_required", "authentication required")
-	}
-	contest, err := s.repo.GetContest(ctx, contestID)
-	if err != nil {
-		return ContestRegistration{}, err
-	}
-	if contest.Visibility == VisibilityPrivate && contest.InviteCodeHash == "" {
-		return ContestRegistration{}, apperror.Forbidden("contest.invite_code_required", "invite code is required")
-	}
-	if contest.Visibility == VisibilityPrivate && contest.InviteCodeHash != hashInviteCode(input.InviteCode) {
-		return ContestRegistration{}, apperror.Forbidden("contest.invite_code_invalid", "invite code is invalid")
-	}
-	displayName := strings.TrimSpace(input.DisplayName)
-	email := strings.TrimSpace(input.Email)
-	if displayName == "" || email == "" {
-		return ContestRegistration{}, apperror.BadRequest("request.invalid", "display_name and email are required")
-	}
-	return s.repo.CreateRegistration(ctx, ContestRegistration{
-		ContestID:   contestID,
-		UserID:      actor.UserID,
-		DisplayName: displayName,
-		Email:       email,
-		Status:      RegistrationActive,
-	})
+	return s.policy.Register(ctx, actor, contestID, input)
 }
 
 func (s *Service) ValidateSubmission(ctx context.Context, actor auth.Actor, problemID, contestID int64) error {
-	if !actor.Authenticated() {
-		return apperror.Unauthorized("auth_required", "authentication required")
-	}
-	contest, err := s.repo.GetContest(ctx, contestID)
-	if err != nil {
-		return err
-	}
-	if contest.Status != StatusPublished && contest.Status != StatusRunning {
-		return apperror.Forbidden("contest.not_started", "contest is not accepting submissions")
-	}
-	now := s.now()
-	if now.Before(contest.StartAt) {
-		return apperror.Forbidden("contest.not_started", "contest has not started")
-	}
-	if !now.Before(contest.EndAt) {
-		return apperror.Forbidden("contest.ended", "contest has ended")
-	}
-	problems, err := s.repo.ListContestProblems(ctx, contestID)
-	if err != nil {
-		return err
-	}
-	if !containsProblem(problems, problemID) {
-		return apperror.NotFound("contest.problem_not_found", "problem is not in contest")
-	}
-	if actor.Admin() || actor.UserID == contest.OwnerUserID {
-		return nil
-	}
-	registration, err := s.repo.GetRegistration(ctx, contestID, actor.UserID)
-	if err != nil || registration.Status != RegistrationActive {
-		return apperror.Forbidden("contest.registration_required", "contest registration required")
-	}
-	return nil
+	return s.policy.ValidateSubmission(ctx, actor, problemID, contestID)
 }
 
 func (s *Service) SubmissionResultVisibility(ctx context.Context, actor auth.Actor, sub submission.ContestSubmissionVisibility) (submission.SubmissionResultVisibility, error) {
-	contest, err := s.repo.GetContest(ctx, sub.ContestID)
-	if err != nil {
-		return submission.SubmissionResultVisibility{}, err
-	}
-	if err := s.canReadContest(ctx, actor, contest); err != nil {
-		return submission.SubmissionResultVisibility{}, err
-	}
-	return submissionResultVisibility(contest, actor, sub, s.now()), nil
+	return s.policy.SubmissionResultVisibility(ctx, actor, sub)
 }
 
 func (s *Service) SubmissionResultVisibilities(ctx context.Context, actor auth.Actor, submissions []submission.ContestSubmissionVisibility) (map[int64]submission.SubmissionResultVisibility, error) {
-	visibilities := make(map[int64]submission.SubmissionResultVisibility, len(submissions))
-	contests := make(map[int64]ContestRecord)
-	now := s.now()
-	for _, sub := range submissions {
-		contest, ok := contests[sub.ContestID]
-		if !ok {
-			var err error
-			contest, err = s.repo.GetContest(ctx, sub.ContestID)
-			if err != nil {
-				return nil, err
-			}
-			if err := s.canReadContest(ctx, actor, contest); err != nil {
-				return nil, err
-			}
-			contests[sub.ContestID] = contest
-		}
-		visibilities[sub.ID] = submissionResultVisibility(contest, actor, sub, now)
-	}
-	return visibilities, nil
+	return s.policy.SubmissionResultVisibilities(ctx, actor, submissions)
 }
 
-func submissionResultVisibility(contest ContestRecord, actor auth.Actor, sub submission.ContestSubmissionVisibility, now time.Time) submission.SubmissionResultVisibility {
-	if actor.Admin() || actor.UserID == contest.OwnerUserID {
-		return submission.SubmissionResultVisibility{ShowResult: true, ShowCases: true, ShowAdminDiagnostics: true, Visibility: "visible"}
-	}
-	visible := submissionVisibleInFrozenWindow(contest, sub, now)
-	if !visible {
-		return submission.SubmissionResultVisibility{Visibility: "frozen"}
-	}
-	return submission.SubmissionResultVisibility{ShowResult: true, ShowCases: true, Visibility: "visible"}
+func (s *Service) Scoreboard(ctx context.Context, actor auth.Actor, contestID int64, requested ScoreboardView) (ScoreboardResponse, error) {
+	return s.scoreboard.Scoreboard(ctx, actor, contestID, requested)
 }
 
-func submissionVisibleInFrozenWindow(contest ContestRecord, sub submission.ContestSubmissionVisibility, now time.Time) bool {
-	if now.Before(contest.FreezeAt) || !now.Before(contest.EndAt) {
-		return true
-	}
-	if sub.JudgedAt == nil {
-		return sub.SubmittedAt.Before(contest.FreezeAt)
-	}
-	return sub.SubmittedAt.Before(contest.FreezeAt) && !sub.JudgedAt.After(contest.FreezeAt)
+func (s *Service) GenerateDueScoreSnapshots(ctx context.Context, limit int32) (ScoreSnapshotGenerationResult, error) {
+	return s.scoreboard.GenerateDueScoreSnapshots(ctx, limit)
 }
 
 func (s *Service) AfterSubmissionTerminal(ctx context.Context, terminal submission.TerminalSubmission) error {
-	if terminal.ContestID == nil {
-		return nil
-	}
-	return s.recordTerminalSubmission(ctx, terminal)
-}
-
-func (s *Service) withFrontendContract(ctx context.Context, actor auth.Actor, record ContestRecord) (ContestRecord, error) {
-	problems, err := s.repo.ListContestProblems(ctx, record.ID)
-	if err != nil {
-		return ContestRecord{}, err
-	}
-	record.Problems = problems
-	record.ScoringMode = ScoringModeACM
-	record.Registered = s.actorRegisteredForContest(ctx, actor, record.ID)
-	return record, nil
-}
-
-func (s *Service) actorRegisteredForContest(ctx context.Context, actor auth.Actor, contestID int64) bool {
-	if !actor.Authenticated() {
-		return false
-	}
-	registration, err := s.repo.GetRegistration(ctx, contestID, actor.UserID)
-	return err == nil && registration.Status == RegistrationActive
-}
-
-func (s *Service) canReadContest(ctx context.Context, actor auth.Actor, contest ContestRecord) error {
-	if contest.Visibility == VisibilityPublic || actor.Admin() || actor.UserID == contest.OwnerUserID {
-		return nil
-	}
-	if !actor.Authenticated() {
-		return apperror.Unauthorized("auth_required", "authentication required")
-	}
-	registration, err := s.repo.GetRegistration(ctx, contest.ID, actor.UserID)
-	if err == nil && registration.Status == RegistrationActive {
-		return nil
-	}
-	return apperror.Forbidden("contest.not_allowed", "contest access denied")
+	return s.projection.AfterSubmissionTerminal(ctx, terminal)
 }
 
 func requireContestWriter(actor auth.Actor, contest ContestRecord) error {

--- a/internal/contest/service_ports_test.go
+++ b/internal/contest/service_ports_test.go
@@ -1,0 +1,183 @@
+package contest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"SOJ/internal/auth"
+	"SOJ/internal/submission"
+)
+
+type contestReaderStoreStub struct{}
+
+func (contestReaderStoreStub) GetContest(context.Context, int64) (ContestRecord, error) {
+	return ContestRecord{ID: 1, OwnerUserID: 7, Visibility: VisibilityPublic, Status: StatusPublished}, nil
+}
+
+func (contestReaderStoreStub) ListContests(context.Context, ListContestFilter) ([]ContestRecord, int64, error) {
+	return nil, 0, nil
+}
+
+func (contestReaderStoreStub) ListContestsByCursor(context.Context, ListContestFilter) ([]ContestRecord, error) {
+	return nil, nil
+}
+
+func (contestReaderStoreStub) ListContestProblems(context.Context, int64) ([]ContestProblem, error) {
+	return []ContestProblem{{ProblemID: 101, Alias: "A"}}, nil
+}
+
+func (contestReaderStoreStub) GetRegistration(context.Context, int64, int64) (ContestRegistration, error) {
+	return ContestRegistration{}, nil
+}
+
+func (contestReaderStoreStub) ListRegistrations(context.Context, int64) ([]ContestRegistration, error) {
+	return nil, nil
+}
+
+type contestAuthoringStoreStub struct{}
+
+func (contestAuthoringStoreStub) GetContest(context.Context, int64) (ContestRecord, error) {
+	return ContestRecord{ID: 1, OwnerUserID: 7, Visibility: VisibilityPublic, Status: StatusDraft}, nil
+}
+
+func (contestAuthoringStoreStub) ArchiveContest(_ context.Context, id int64) (ContestRecord, error) {
+	return ContestRecord{ID: id, Status: StatusArchived}, nil
+}
+
+func (contestAuthoringStoreStub) WithTx(ctx context.Context, fn func(context.Context, contestTransaction) error) error {
+	return fn(ctx, contestTransactionStub{})
+}
+
+type contestRegistrationWriterStub struct{}
+
+func (contestRegistrationWriterStub) CreateRegistration(_ context.Context, registration ContestRegistration) (ContestRegistration, error) {
+	return registration, nil
+}
+
+type scoreboardStoreStub struct{}
+
+func (scoreboardStoreStub) ListProblemResults(context.Context, int64) ([]ContestProblemResult, error) {
+	return nil, nil
+}
+
+func (scoreboardStoreStub) ListTerminalSubmissions(context.Context, int64) ([]ContestSubmissionResult, error) {
+	return nil, nil
+}
+
+func (scoreboardStoreStub) ListScoreSnapshotCandidates(context.Context, time.Time, int32) ([]ScoreSnapshotCandidate, error) {
+	return nil, nil
+}
+
+func (scoreboardStoreStub) CreateScoreSnapshot(context.Context, ScoreboardSnapshot) (ScoreboardSnapshot, error) {
+	return ScoreboardSnapshot{}, nil
+}
+
+func (scoreboardStoreStub) LatestScoreSnapshot(context.Context, int64, ScoreboardView) (ScoreboardSnapshot, error) {
+	return ScoreboardSnapshot{}, nil
+}
+
+type scoreboardProjectionStoreStub struct {
+	called bool
+}
+
+func (scoreboardProjectionStoreStub) ListProblemResults(context.Context, int64) ([]ContestProblemResult, error) {
+	return nil, nil
+}
+
+func (s *scoreboardProjectionStoreStub) UpsertProblemResult(_ context.Context, result ContestProblemResult) (ContestProblemResult, error) {
+	s.called = true
+	return result, nil
+}
+
+type contestTransactionStub struct{}
+
+func (contestTransactionStub) CreateContest(context.Context, ContestRecord) (ContestRecord, error) {
+	return ContestRecord{ID: 1}, nil
+}
+
+func (contestTransactionStub) UpdateContest(context.Context, int64, ContestUpdateInput) (ContestRecord, error) {
+	return ContestRecord{ID: 1}, nil
+}
+
+func (contestTransactionStub) ReplaceContestProblems(context.Context, int64, []ContestProblem) error {
+	return nil
+}
+
+func TestContestComponentsUseFocusedPorts(t *testing.T) {
+	reader := NewContestReader(contestReaderStoreStub{}, nil)
+	authoring := NewContestAuthoring(contestAuthoringStoreStub{}, reader)
+	policy := NewContestPolicy(reader, contestRegistrationWriterStub{})
+	scoreboard := NewScoreboardService(reader, scoreboardStoreStub{})
+	projectionStore := &scoreboardProjectionStoreStub{}
+	projection := NewScoreboardProjection(reader, projectionStore)
+
+	if _, err := reader.GetContest(t.Context(), auth.Anonymous("request"), 1); err != nil {
+		t.Fatalf("ContestReader.GetContest() error = %v", err)
+	}
+	if _, err := authoring.DeleteContest(t.Context(), auth.Actor{UserID: 99, Role: auth.RoleAdmin}, 1); err != nil {
+		t.Fatalf("ContestAuthoring.DeleteContest() error = %v", err)
+	}
+	if _, err := policy.Register(t.Context(), auth.Actor{UserID: 8, Role: auth.RoleUser}, 1, RegistrationInput{DisplayName: "alice", Email: "alice@example.com"}); err != nil {
+		t.Fatalf("ContestPolicy.Register() error = %v", err)
+	}
+	if _, err := scoreboard.GenerateDueScoreSnapshots(t.Context(), 1); err != nil {
+		t.Fatalf("ScoreboardService.GenerateDueScoreSnapshots() error = %v", err)
+	}
+	contestID := int64(1)
+	judgedAt := time.Unix(100, 0).UTC()
+	if err := projection.AfterSubmissionTerminal(t.Context(), submission.TerminalSubmission{ContestID: &contestID, UserID: 8, ProblemID: 101, Status: submission.StatusWrongAnswer, SubmittedAt: judgedAt, JudgedAt: judgedAt}); err != nil {
+		t.Fatalf("ScoreboardProjection.AfterSubmissionTerminal() error = %v", err)
+	}
+	if !projectionStore.called {
+		t.Fatal("ScoreboardProjection did not write the projection store")
+	}
+}
+
+func TestServiceAuthorizeContestRejudgeUsesReaderComponent(t *testing.T) {
+	reader := NewContestReader(contestReaderStoreStub{}, nil)
+	service := NewService(
+		reader,
+		NewContestAuthoring(contestAuthoringStoreStub{}, reader),
+		NewContestPolicy(reader, contestRegistrationWriterStub{}),
+		NewScoreboardService(reader, scoreboardStoreStub{}),
+		NewScoreboardProjection(reader, &scoreboardProjectionStoreStub{}),
+	)
+
+	if err := service.AuthorizeContestRejudge(t.Context(), auth.Actor{UserID: 99, Role: auth.RoleAdmin}, 1); err != nil {
+		t.Fatalf("AuthorizeContestRejudge() error = %v", err)
+	}
+}
+
+func TestContestConstructorsRejectMissingDependencies(t *testing.T) {
+	reader := NewContestReader(contestReaderStoreStub{}, nil)
+	projectionStore := &scoreboardProjectionStoreStub{}
+	tests := []struct {
+		name string
+		new  func()
+	}{
+		{name: "reader store", new: func() { NewContestReader(nil, nil) }},
+		{name: "authoring store", new: func() { NewContestAuthoring(nil, reader) }},
+		{name: "authoring reader", new: func() { NewContestAuthoring(contestAuthoringStoreStub{}, nil) }},
+		{name: "policy reader", new: func() { NewContestPolicy(nil, contestRegistrationWriterStub{}) }},
+		{name: "policy writer", new: func() { NewContestPolicy(reader, nil) }},
+		{name: "scoreboard reader", new: func() { NewScoreboardService(nil, scoreboardStoreStub{}) }},
+		{name: "scoreboard store", new: func() { NewScoreboardService(reader, nil) }},
+		{name: "projection reader", new: func() { NewScoreboardProjection(nil, projectionStore) }},
+		{name: "projection store", new: func() { NewScoreboardProjection(reader, nil) }},
+		{name: "service reader", new: func() {
+			NewService(nil, NewContestAuthoring(contestAuthoringStoreStub{}, reader), NewContestPolicy(reader, contestRegistrationWriterStub{}), NewScoreboardService(reader, scoreboardStoreStub{}), NewScoreboardProjection(reader, projectionStore))
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("constructor did not panic")
+				}
+			}()
+			tt.new()
+		})
+	}
+}

--- a/internal/contest/service_test.go
+++ b/internal/contest/service_test.go
@@ -11,6 +11,21 @@ import (
 	"SOJ/internal/submission"
 )
 
+func newContestService(repo *memoryRepository, now ...func() time.Time) *Service {
+	clock := time.Now
+	if len(now) > 0 && now[0] != nil {
+		clock = now[0]
+	}
+	reader := NewContestReader(repo, clock)
+	return NewService(
+		reader,
+		NewContestAuthoring(repo, reader),
+		NewContestPolicy(reader, repo),
+		NewScoreboardService(reader, repo),
+		NewScoreboardProjection(reader, repo),
+	)
+}
+
 func TestScoreboardUsesACMPenaltyAndTieRank(t *testing.T) {
 	start := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
 	repo := newMemoryRepository()
@@ -39,7 +54,7 @@ func TestScoreboardUsesACMPenaltyAndTieRank(t *testing.T) {
 		{ContestID: 1, UserID: 22, ProblemID: 101, Status: CellAccepted, Attempts: 1, AcceptedAt: testTimePtr(start.Add(35 * time.Minute)), PenaltyMinutes: 35},
 		{ContestID: 1, UserID: 22, ProblemID: 102, Status: CellAttempted, Attempts: 2},
 	}
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(90 * time.Minute) }))
+	service := newContestService(repo, func() time.Time { return start.Add(90 * time.Minute) })
 
 	board, err := service.Scoreboard(context.Background(), auth.Actor{UserID: 30, Role: auth.RoleUser}, 1, ScoreboardViewLive)
 	if err != nil {
@@ -85,7 +100,7 @@ func TestFrozenScoreboardHidesAttemptsAfterFreeze(t *testing.T) {
 		{ID: 2, ContestID: 1, UserID: 20, ProblemID: 102, Status: CellAttempted, SubmittedAt: freeze.Add(5 * time.Minute), JudgedAt: freeze.Add(6 * time.Minute)},
 		{ID: 3, ContestID: 1, UserID: 20, ProblemID: 102, Status: CellAccepted, SubmittedAt: freeze.Add(7 * time.Minute), JudgedAt: freeze.Add(8 * time.Minute)},
 	}
-	service := NewService(repo, WithNow(func() time.Time { return freeze.Add(30 * time.Minute) }))
+	service := newContestService(repo, func() time.Time { return freeze.Add(30 * time.Minute) })
 
 	board, err := service.Scoreboard(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1, ScoreboardViewFrozen)
 	if err != nil {
@@ -115,7 +130,7 @@ func TestSubmissionResultVisibilityUsesContestFreezePolicy(t *testing.T) {
 		EndAt:       end,
 		FreezeAt:    freeze,
 	}
-	service := NewService(repo, WithNow(func() time.Time { return freeze.Add(30 * time.Minute) }))
+	service := newContestService(repo, func() time.Time { return freeze.Add(30 * time.Minute) })
 	contestant := auth.Actor{UserID: 20, Role: auth.RoleUser}
 
 	judgedBeforeFreeze := freeze.Add(-time.Minute)
@@ -180,7 +195,7 @@ func TestSubmissionResultVisibilityUsesContestFreezePolicy(t *testing.T) {
 		t.Fatalf("admin policy = %+v", adminVisible)
 	}
 
-	finalService := NewService(repo, WithNow(func() time.Time { return end.Add(time.Minute) }))
+	finalService := newContestService(repo, func() time.Time { return end.Add(time.Minute) })
 	finalVisible, err := finalService.SubmissionResultVisibility(context.Background(), contestant, submission.ContestSubmissionVisibility{
 		ID:          5,
 		UserID:      20,
@@ -221,7 +236,7 @@ func TestSubmissionResultVisibilitiesCachesContestAccessPerContest(t *testing.T)
 		FreezeAt:    start.Add(2 * time.Hour),
 	}
 	repo.registrations[2] = []ContestRegistration{{ContestID: 2, UserID: 20, Status: RegistrationActive}}
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(time.Hour) }))
+	service := newContestService(repo, func() time.Time { return start.Add(time.Hour) })
 
 	visibilities, err := service.SubmissionResultVisibilities(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, []submission.ContestSubmissionVisibility{
 		{ID: 1, UserID: 20, ProblemID: 101, ContestID: 1, SubmittedAt: start.Add(time.Minute)},
@@ -261,7 +276,7 @@ func TestFinalScoreboardFallsBackToProblemResultsWhenSnapshotMissing(t *testing.
 	repo.problems[1] = []ContestProblem{{ContestID: 1, ProblemID: 101, Alias: "A", SortOrder: 1}}
 	repo.registrations[1] = []ContestRegistration{{ID: 1, ContestID: 1, UserID: 20, DisplayName: "alice", Email: "alice@example.com", Status: RegistrationActive}}
 	repo.results[1] = []ContestProblemResult{{ContestID: 1, UserID: 20, ProblemID: 101, Status: CellAccepted, Attempts: 1, AcceptedAt: testTimePtr(start.Add(40 * time.Minute)), PenaltyMinutes: 40}}
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(2 * time.Hour) }))
+	service := newContestService(repo, func() time.Time { return start.Add(2 * time.Hour) })
 
 	board, err := service.Scoreboard(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1, ScoreboardViewFinal)
 	if err != nil {
@@ -299,7 +314,7 @@ func TestGenerateDueScoreSnapshotsCreatesFrozenAndFinalOnce(t *testing.T) {
 	repo.results[1] = []ContestProblemResult{
 		{ContestID: 1, UserID: 20, ProblemID: 101, Status: CellAccepted, Attempts: 1, AcceptedAt: testTimePtr(freeze.Add(10 * time.Minute)), PenaltyMinutes: 70},
 	}
-	service := NewService(repo, WithNow(func() time.Time { return now }))
+	service := newContestService(repo, func() time.Time { return now })
 
 	created, err := service.GenerateDueScoreSnapshots(context.Background(), 10)
 	if err != nil {
@@ -349,7 +364,7 @@ func TestLiveScoreboardAfterFreezeRequiresOwnerOrAdmin(t *testing.T) {
 		FreezeAt:    start.Add(time.Hour),
 	}
 	repo.problems[1] = []ContestProblem{{ContestID: 1, ProblemID: 101, Alias: "A", SortOrder: 1}}
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(90 * time.Minute) }))
+	service := newContestService(repo, func() time.Time { return start.Add(90 * time.Minute) })
 
 	_, err := service.Scoreboard(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 1, ScoreboardViewLive)
 	if codeOf(err) != "contest.scoreboard_hidden" {
@@ -370,7 +385,7 @@ func TestListContestsAppliesVisibilityRules(t *testing.T) {
 	repo.contests[2] = ContestRecord{ID: 2, OwnerUserID: 10, Title: "Private", Visibility: VisibilityPrivate, Status: StatusPublished, StartAt: start, EndAt: start.Add(time.Hour), FreezeAt: start.Add(30 * time.Minute)}
 	repo.contests[3] = ContestRecord{ID: 3, OwnerUserID: 30, Title: "Registered", Visibility: VisibilityPrivate, Status: StatusPublished, StartAt: start, EndAt: start.Add(time.Hour), FreezeAt: start.Add(30 * time.Minute)}
 	repo.registrations[3] = []ContestRegistration{{ID: 1, ContestID: 3, UserID: 20, Status: RegistrationActive}}
-	service := NewService(repo)
+	service := newContestService(repo)
 
 	anonymous, err := service.ListContests(context.Background(), auth.Anonymous("req"), ListContestFilter{})
 	if err != nil {
@@ -402,7 +417,7 @@ func TestListContestsByCursorReturnsNextCursor(t *testing.T) {
 	repo := newMemoryRepository()
 	repo.contests[2] = ContestRecord{ID: 2, Title: "Second", Visibility: VisibilityPublic, Status: StatusPublished, StartAt: start.Add(-time.Minute), EndAt: start, FreezeAt: start}
 	repo.contests[1] = ContestRecord{ID: 1, Title: "First", Visibility: VisibilityPublic, Status: StatusPublished, StartAt: start.Add(-2 * time.Minute), EndAt: start, FreezeAt: start}
-	service := NewService(repo)
+	service := newContestService(repo)
 
 	page, err := service.ListContestsByCursor(context.Background(), auth.Anonymous("req"), ListContestFilter{PageSize: 1})
 	if err != nil {
@@ -430,7 +445,7 @@ func TestContestResponsesIncludeFrontendContractFields(t *testing.T) {
 	repo.contests[1] = ContestRecord{ID: 1, OwnerUserID: 10, Title: "Public", Visibility: VisibilityPublic, Status: StatusPublished, StartAt: start, EndAt: start.Add(time.Hour), FreezeAt: start.Add(30 * time.Minute)}
 	repo.problems[1] = []ContestProblem{{ContestID: 1, ProblemID: 101, Alias: "A", SortOrder: 1, Title: "Two Sum"}}
 	repo.registrations[1] = []ContestRegistration{{ID: 1, ContestID: 1, UserID: 20, Status: RegistrationActive}}
-	service := NewService(repo)
+	service := newContestService(repo)
 	actor := auth.Actor{UserID: 20, Role: auth.RoleUser}
 
 	list, err := service.ListContests(context.Background(), actor, ListContestFilter{})
@@ -460,7 +475,7 @@ func TestAuthorizeContestRejudgeRequiresWriterAndEndedContest(t *testing.T) {
 	repo := newMemoryRepository()
 	repo.contests[1] = ContestRecord{ID: 1, OwnerUserID: 10, Status: StatusEnded, Visibility: VisibilityPublic}
 	repo.contests[2] = ContestRecord{ID: 2, OwnerUserID: 10, Status: StatusRunning, Visibility: VisibilityPublic}
-	service := NewService(repo)
+	service := newContestService(repo)
 
 	if err := service.AuthorizeContestRejudge(t.Context(), auth.Actor{UserID: 10, Role: auth.RoleUser}, 1); err != nil {
 		t.Fatalf("owner authorization returned error: %v", err)
@@ -479,7 +494,7 @@ func TestAuthorizeContestRejudgeRequiresWriterAndEndedContest(t *testing.T) {
 func TestContestCRUDRegistrationAndPermissions(t *testing.T) {
 	start := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
 	repo := newMemoryRepository()
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(-time.Hour) }))
+	service := newContestService(repo, func() time.Time { return start.Add(-time.Hour) })
 	owner := auth.Actor{UserID: 10, Role: auth.RoleUser}
 
 	_, err := service.CreateContest(context.Background(), owner, ContestInput{
@@ -571,7 +586,7 @@ func TestContestCRUDRegistrationAndPermissions(t *testing.T) {
 func TestPrivateContestRequiresInviteCode(t *testing.T) {
 	start := time.Date(2026, 7, 5, 10, 0, 0, 0, time.UTC)
 	repo := newMemoryRepository()
-	service := NewService(repo)
+	service := newContestService(repo)
 	owner := auth.Actor{UserID: 10, Role: auth.RoleUser}
 
 	_, err := service.CreateContest(context.Background(), owner, ContestInput{
@@ -614,7 +629,7 @@ func TestValidateSubmissionRequiresPublishedRegistrationAndWindow(t *testing.T) 
 	repo := newMemoryRepository()
 	repo.contests[1] = ContestRecord{ID: 1, OwnerUserID: 10, Visibility: VisibilityPrivate, Status: StatusPublished, StartAt: start, EndAt: start.Add(time.Hour), FreezeAt: start.Add(30 * time.Minute)}
 	repo.problems[1] = []ContestProblem{{ContestID: 1, ProblemID: 101, Alias: "A", SortOrder: 1}}
-	service := NewService(repo, WithNow(func() time.Time { return start.Add(10 * time.Minute) }))
+	service := newContestService(repo, func() time.Time { return start.Add(10 * time.Minute) })
 
 	err := service.ValidateSubmission(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 101, 1)
 	if codeOf(err) != "contest.registration_required" {
@@ -629,7 +644,7 @@ func TestValidateSubmissionRequiresPublishedRegistrationAndWindow(t *testing.T) 
 		t.Fatalf("outside problem error = %v", err)
 	}
 
-	service = NewService(repo, WithNow(func() time.Time { return start.Add(2 * time.Hour) }))
+	service = newContestService(repo, func() time.Time { return start.Add(2 * time.Hour) })
 	err = service.ValidateSubmission(context.Background(), auth.Actor{UserID: 20, Role: auth.RoleUser}, 101, 1)
 	if codeOf(err) != "contest.ended" {
 		t.Fatalf("ended submit error = %v", err)

--- a/internal/contest/submission.go
+++ b/internal/contest/submission.go
@@ -6,13 +6,43 @@ import (
 	"SOJ/internal/submission"
 )
 
-func (s *Service) recordTerminalSubmission(ctx context.Context, terminal submission.TerminalSubmission) error {
+type scoreboardProjectionStore interface {
+	ListProblemResults(context.Context, int64) ([]ContestProblemResult, error)
+	UpsertProblemResult(context.Context, ContestProblemResult) (ContestProblemResult, error)
+}
+
+// ScoreboardProjection updates the contest result projection after terminal submissions.
+type ScoreboardProjection struct {
+	reader *ContestReader
+	store  scoreboardProjectionStore
+}
+
+// NewScoreboardProjection builds the terminal result projection workflow.
+func NewScoreboardProjection(reader *ContestReader, store scoreboardProjectionStore) *ScoreboardProjection {
+	if reader == nil {
+		panic("scoreboard projection reader is required")
+	}
+	if store == nil {
+		panic("scoreboard projection store is required")
+	}
+	return &ScoreboardProjection{reader: reader, store: store}
+}
+
+// AfterSubmissionTerminal updates the contest result projection for a terminal submission.
+func (s *ScoreboardProjection) AfterSubmissionTerminal(ctx context.Context, terminal submission.TerminalSubmission) error {
+	if terminal.ContestID == nil {
+		return nil
+	}
+	return s.recordTerminalSubmission(ctx, terminal)
+}
+
+func (s *ScoreboardProjection) recordTerminalSubmission(ctx context.Context, terminal submission.TerminalSubmission) error {
 	contestID := *terminal.ContestID
-	contest, err := s.repo.GetContest(ctx, contestID)
+	contest, err := s.reader.getContest(ctx, contestID)
 	if err != nil {
 		return err
 	}
-	problems, err := s.repo.ListContestProblems(ctx, contestID)
+	problems, err := s.reader.listContestProblems(ctx, contestID)
 	if err != nil {
 		return err
 	}
@@ -20,7 +50,7 @@ func (s *Service) recordTerminalSubmission(ctx context.Context, terminal submiss
 		return nil
 	}
 	existing := ContestProblemResult{ContestID: contestID, UserID: terminal.UserID, ProblemID: terminal.ProblemID, Status: CellNone}
-	results, err := s.repo.ListProblemResults(ctx, contestID)
+	results, err := s.store.ListProblemResults(ctx, contestID)
 	if err != nil {
 		return err
 	}
@@ -48,6 +78,6 @@ func (s *Service) recordTerminalSubmission(ctx context.Context, terminal submiss
 	} else {
 		existing.Status = CellAttempted
 	}
-	_, err = s.repo.UpsertProblemResult(ctx, existing)
+	_, err = s.store.UpsertProblemResult(ctx, existing)
 	return err
 }


### PR DESCRIPTION
## Summary

Resolves the contest-specific storage boundary work in #56 without changing the contest API, scoring rules, freeze behavior, snapshot semantics, or database schema.

- Split contest reads, authoring, policies, scoreboard workflows, and result projection behind focused consumer-owned ports.
- Keep the contest create/update problem replacement transaction boundary explicit.
- Compose the HTTP-facing service from focused workflows; the worker depends only on scoreboard snapshot generation.
- Add focused-port constructor and behavior coverage.

## Validation

- go test -count=1 ./...
- go test -count=1 -race ./internal/contest
- go vet ./...
- golangci-lint run

Fixes #56